### PR TITLE
[GrCUDA-66] fix arity deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2021-11-29
+
+* Removed deprecation warning for Truffle's ArityException. 
+
 # 2021-11-17
 
 * Added the support of precise timing of kernels, for debugging and complex scheduling policies

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cudalibraries/cuml/CUMLRegistry.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cudalibraries/cuml/CUMLRegistry.java
@@ -128,7 +128,7 @@ public class CUMLRegistry {
                 @TruffleBoundary
                 public Object call(Object[] arguments) throws ArityException {
                     checkArgumentLength(arguments, 2);
-                    try (UnsafeHelper.Integer64Object handle = UnsafeHelper.createInteger64Object()) {
+                    try {
                         long stream_handle = expectLong(arguments[0]);
                         long streamID = expectLong(arguments[1]);
                         Object result = INTEROP.execute(cumlSetStreamFunctionNFI, stream_handle, streamID);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/DeviceArrayCopyFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/DeviceArrayCopyFunction.java
@@ -102,7 +102,7 @@ public class DeviceArrayCopyFunction implements TruffleObject {
             numElements = extractNumber(arguments[1], numElementsAccess);
         } else {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(1, arguments.length);
+            throw ArityException.create(1, 2, arguments.length);
         }
         // Obtain what kind of copy (pointer or array) should be executed.
         // By default, see if we can use the fast CUDA memcpy: we cannot use it if the source and target arrays

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/DeviceArrayFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/DeviceArrayFunction.java
@@ -77,7 +77,7 @@ public final class DeviceArrayFunction extends Function {
     @TruffleBoundary
     public Object call(Object[] arguments) throws ArityException, UnsupportedTypeException {
         if (arguments.length < 1) {
-            throw ArityException.create(1, arguments.length);
+            throw ArityException.create(1, 2, arguments.length);
         }
         String typeName = expectString(arguments[0], "first argument of DeviceArray must be string (type name)");
         Type elementType;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/Function.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/Function.java
@@ -112,7 +112,14 @@ public abstract class Function implements TruffleObject {
     public static void checkArgumentLength(Object[] arguments, int expected) throws ArityException {
         if (arguments.length != expected) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(expected, arguments.length);
+            throw ArityException.create(expected, expected, arguments.length);
+        }
+    }
+
+    public static void checkArgumentLength(Object[] arguments, int minExpected, int maxExpected) throws ArityException {
+        if (arguments.length < minExpected || arguments.length > maxExpected) {
+            CompilerDirectives.transferToInterpreter();
+            throw ArityException.create(minExpected, maxExpected, arguments.length);
         }
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/MapDeviceArrayFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/MapDeviceArrayFunction.java
@@ -227,7 +227,7 @@ public final class MapDeviceArrayFunction extends Function {
                     @Cached MapArrayNode mapNode) throws ArityException, UnsupportedTypeException {
         if (arguments.length < 1) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(1, arguments.length);
+            throw ArityException.create(1, 2, arguments.length);
         }
         String typeName;
         try {
@@ -244,12 +244,11 @@ public final class MapDeviceArrayFunction extends Function {
         }
         if (arguments.length == 1) {
             return new TypedMapDeviceArrayFunction(grCUDAExecutionContext, elementType);
-        } else {
-            if (arguments.length != 2) {
-                CompilerDirectives.transferToInterpreter();
-                throw ArityException.create(2, arguments.length);
-            }
+        } else if (arguments.length == 2) {
             return mapNode.execute(arguments[1], elementType, grCUDAExecutionContext);
+        } else {
+            CompilerDirectives.transferToInterpreter();
+            throw ArityException.create(1, 2, arguments.length);
         }
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/TypedDeviceArrayFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/TypedDeviceArrayFunction.java
@@ -61,7 +61,9 @@ public final class TypedDeviceArrayFunction extends Function {
     public Object call(Object[] arguments) throws ArityException, UnsupportedTypeException {
         if (arguments.length < 1) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(1, arguments.length);
+            // FIXME: the maximum number of arguments is unbound (as each argument is a dimension of a N-dimensional tensor).
+            //  Truffle currently uses -1 to handle an unbound number of arguments;
+            throw ArityException.create(1, -1, arguments.length);
         }
         return DeviceArrayFunction.createArray(arguments, 0, elementType, grCUDAExecutionContext);
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/TypedMapDeviceArrayFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/TypedMapDeviceArrayFunction.java
@@ -64,7 +64,7 @@ public final class TypedMapDeviceArrayFunction extends Function {
                     @Cached MapArrayNode mapNode) throws ArityException {
         if (arguments.length != 1) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(1, arguments.length);
+            throw ArityException.create(1, 1, arguments.length);
         }
         return mapNode.execute(arguments[0], elementType, grCUDAExecutionContext);
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/map/MapFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/map/MapFunction.java
@@ -120,7 +120,7 @@ public final class MapFunction extends com.nvidia.grcuda.functions.Function {
     static void checkArity(Object[] arguments, int expectedArity) throws ArityException {
         if (arguments.length != expectedArity) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(expectedArity, arguments.length);
+            throw ArityException.create(expectedArity, expectedArity, arguments.length);
         }
     }
 
@@ -175,7 +175,9 @@ public final class MapFunction extends com.nvidia.grcuda.functions.Function {
         static MapFunctionBase readMemberSize(MapFunction receiver, String member) {
             return new MapFunctionBase(arguments -> {
                 if (arguments.length == 0) {
-                    throw ArityException.create(1, 0);
+                    // FIXME: the maximum number of arguments is unbound.
+                    //  Truffle currently uses -1 to handle an unbound number of arguments;
+                    throw ArityException.create(1, -1, 0);
                 }
                 try {
                     return receiver.size((MapArgObject) arguments[0], Arrays.copyOfRange(arguments, 1, arguments.length, MapArgObject[].class));
@@ -189,7 +191,9 @@ public final class MapFunction extends com.nvidia.grcuda.functions.Function {
         static MapFunctionBase readMemberValue(MapFunction receiver, String member) {
             return new MapFunctionBase(arguments -> {
                 if (arguments.length < 1) {
-                    throw ArityException.create(1, arguments.length);
+                    // FIXME: the maximum number of arguments is unbound.
+                    //  Truffle currently uses -1 to handle an unbound number of arguments;
+                    throw ArityException.create(1, -1, arguments.length);
                 }
                 String name = checkString(arguments[0], "name of created value expected");
                 if (arguments.length == 1) {
@@ -225,7 +229,9 @@ public final class MapFunction extends com.nvidia.grcuda.functions.Function {
     @TruffleBoundary
     public MappedFunction execute(Object[] arguments) throws ArityException, UnsupportedTypeException {
         if (arguments.length == 0) {
-            throw ArityException.create(1, 0);
+            // FIXME: the maximum number of arguments is unbound.
+            //  Truffle currently uses -1 to handle an unbound number of arguments;
+            throw ArityException.create(1, -1, 0);
         }
         Object function = arguments[0];
         if (!INTEROP.isExecutable(function)) {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/map/MappedFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/map/MappedFunction.java
@@ -236,7 +236,7 @@ final class MapBoundArgObjectSize extends MapBoundArgObjectBase {
                     @Cached("createEqualityProfile()") PrimitiveValueProfile lengthProfile) throws ArityException {
         if (arguments.length != 3) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(3, arguments.length);
+            throw ArityException.create(3, 3, arguments.length);
         }
         long size;
         try {
@@ -355,7 +355,7 @@ final class MapBoundArgObjectValue extends MapBoundArgObjectBase {
                     @Cached("createEqualityProfile()") PrimitiveValueProfile lengthProfile) throws ArityException {
         if (arguments.length != 3) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(3, arguments.length);
+            throw ArityException.create(3, 3, arguments.length);
         }
         int length = lengthProfile.profile(args.length);
         Object[] mappedArgs = new Object[length];
@@ -443,7 +443,7 @@ final class MapBoundArgObjectMember extends MapBoundArgObjectBase {
                     @CachedLibrary(limit = "2") InteropLibrary memberInterop) throws ArityException, UnsupportedTypeException, UnsupportedMessageException {
         if (arguments.length != 3) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(3, arguments.length);
+            throw ArityException.create(3, 3, arguments.length);
         }
         Object value = parentInterop.execute(parent, arguments);
         try {
@@ -503,7 +503,7 @@ final class MapBoundArgObjectElement extends MapBoundArgObjectBase {
                     @CachedLibrary(limit = "2") InteropLibrary elementInterop) throws ArityException, UnsupportedTypeException, UnsupportedMessageException {
         if (arguments.length != 3) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(3, arguments.length);
+            throw ArityException.create(3, 3, arguments.length);
         }
         Object value = parentInterop.execute(parent, arguments);
         try {
@@ -563,7 +563,7 @@ final class MapBoundArgObjectMap extends MapBoundArgObjectBase {
                     @CachedLibrary("this.function") InteropLibrary mapInterop) throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
         if (arguments.length != 3) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(3, arguments.length);
+            throw ArityException.create(3, 3, arguments.length);
         }
         Object value = parentInterop.execute(parent, arguments);
         try {
@@ -639,7 +639,7 @@ final class MapBoundArgObjectShred extends MapBoundArgObjectBase {
                     @CachedLibrary("this.parent") InteropLibrary parentInterop) throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
         if (arguments.length != 3) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(3, arguments.length);
+            throw ArityException.create(3, 3, arguments.length);
         }
         return new ShreddedObject(parentInterop.execute(parent, arguments));
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CUDARuntime.java
@@ -900,7 +900,7 @@ public final class CUDARuntime {
                     }
                 } else {
                     CompilerDirectives.transferToInterpreter();
-                    throw ArityException.create(3, args.length);
+                    throw ArityException.create(1, 3, args.length);
                 }
 
                 // Extract pointers;
@@ -944,7 +944,7 @@ public final class CUDARuntime {
                     streamObj = args[3];
                 } else {
                     CompilerDirectives.transferToInterpreter();
-                    throw ArityException.create(4, args.length);
+                    throw ArityException.create(3, 4, args.length);
                 }
 
                 if (args[1] instanceof Long) {
@@ -1005,12 +1005,10 @@ public final class CUDARuntime {
             public Object call(CUDARuntime cudaRuntime, Object[] args) throws ArityException, UnsupportedTypeException, InteropException {
                 checkArgumentLength(args, 3);
 
-                Object pointerFloat = args[0];
                 Object pointerStartEvent = args[1];
                 Object pointerEndEvent = args[2];
                 long addrStart;
                 long addrEnd;
-                long addrFloat;
 
                 if (pointerStartEvent instanceof CUDAEvent) {
                     addrStart = ((CUDAEvent) pointerStartEvent).getRawPointer();
@@ -1022,12 +1020,10 @@ public final class CUDARuntime {
                 } else {
                     throw new GrCUDAException("expected CUDAEvent object");
                 }
-
                 try (UnsafeHelper.Float32Object floatPointer = UnsafeHelper.createFloat32Object()) {
                     callSymbol(cudaRuntime, floatPointer.getAddress(), addrStart, addrEnd );
                     return NoneValue.get();
                 }
-
             }
         },
         CUDA_EVENTRECORD("cudaEventRecord", "(pointer, pointer): sint32") {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/ConfiguredKernel.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/ConfiguredKernel.java
@@ -88,7 +88,7 @@ public class ConfiguredKernel extends ProfilableElement implements TruffleObject
             throws UnsupportedTypeException, ArityException {
         if (args.length != kernel.getKernelParameters().length) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(kernel.getKernelParameters().length, args.length);
+            throw ArityException.create(kernel.getKernelParameters().length, kernel.getKernelParameters().length, args.length);
         }
         KernelArguments kernelArgs = new KernelArguments(args, this.kernel.getKernelParameters());
         for (int paramIdx = 0; paramIdx < kernel.getKernelParameters().length; paramIdx++) {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/Device.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/Device.java
@@ -176,7 +176,9 @@ final class IsCurrentFunction implements TruffleObject {
     public Object execute(Object[] arguments) throws ArityException {
         if (arguments.length != 0) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(0, arguments.length);
+            // FIXME: the maximum number of arguments is unbound (as each argument is a dimension of a N-dimensional tensor).
+            //  Truffle currently uses -1 to handle an unbound number of arguments;
+            throw ArityException.create(0, -1, arguments.length);
         }
         return runtime.cudaGetDevice() == deviceId;
     }
@@ -203,7 +205,7 @@ class SetCurrentFunction implements TruffleObject {
     public Object execute(Object[] arguments) throws ArityException {
         if (arguments.length != 0) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(0, arguments.length);
+            throw ArityException.create(0, 0, arguments.length);
         }
         runtime.cudaSetDevice(deviceId);
         return NoneValue.get();

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/Kernel.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/Kernel.java
@@ -281,11 +281,9 @@ public class Kernel implements TruffleObject {
                     @CachedLibrary(limit = "3") InteropLibrary blockSizeAccess,
                     @CachedLibrary(limit = "3") InteropLibrary blockSizeElementAccess,
                     @CachedLibrary(limit = "3") InteropLibrary sharedMemoryAccess) throws UnsupportedTypeException, ArityException {
-        // FIXME: ArityException allows to specify only 1 arity, and cannot be subclassed! We might
-        // want to use a custom exception here;
         if (arguments.length < 2 || arguments.length > 4) {
             CompilerDirectives.transferToInterpreter();
-            throw ArityException.create(2, arguments.length);
+            throw ArityException.create(2, 4, arguments.length);
         }
 
         Dim3 gridSize = extractDim3(arguments[0], "gridSize", gridSizeAccess, gridSizeElementAccess);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/AbstractArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/AbstractArray.java
@@ -406,7 +406,7 @@ public abstract class AbstractArray implements TruffleObject {
         Object execute(Object[] arguments) throws ArityException {
             if (arguments.length != 0) {
                 CompilerDirectives.transferToInterpreter();
-                throw ArityException.create(0, arguments.length);
+                throw ArityException.create(0, 0, arguments.length);
             }
             freeMemory();
             return NoneValue.get();


### PR DESCRIPTION
Removed deprecation warning for Truffle's ArityException, which previously could not accept a range of valid arity.
Note: Truffle uses "-1" as the conventional value to denote an unbound maximum number of parameters

Also removed some unnecessary variables 