### PR TITLE
[GrCUDA-96-5] replaced old "isLastComputationArrayAccess" with new device tracking API

### DIFF
--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/functions/DeviceArrayCopyFunctionTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/functions/DeviceArrayCopyFunctionTest.java
@@ -49,6 +49,8 @@ import com.nvidia.grcuda.test.util.GrCUDATestOptionsStruct;
 import com.nvidia.grcuda.test.util.GrCUDATestUtil;
 import com.nvidia.grcuda.test.util.TestLogHandler;
 import com.nvidia.grcuda.test.util.mock.AsyncGrCUDAExecutionContextMock;
+import com.nvidia.grcuda.test.util.mock.DeviceArrayMock;
+import com.nvidia.grcuda.test.util.mock.MultiDimDeviceArrayMock;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.junit.Test;
@@ -67,27 +69,7 @@ import java.util.List;
 public class DeviceArrayCopyFunctionTest {
 
     public static class DeviceArrayCopyFunctionTestNotParameterized {
-        protected static class DeviceArrayMock extends DeviceArray {
-            DeviceArrayMock() {
-                super(new AsyncGrCUDAExecutionContextMock(), 0, Type.SINT32);
-            }
 
-            @Override
-            protected LittleEndianNativeArrayView allocateMemory() {
-                return null;
-            }
-        }
-
-        protected static class MultiDimDeviceArrayMock extends MultiDimDeviceArray {
-            MultiDimDeviceArrayMock(long[] dimensions, boolean columnMajor) {
-                super(new AsyncGrCUDAExecutionContextMock(), Type.SINT32, dimensions, columnMajor);
-            }
-
-            @Override
-            protected LittleEndianNativeArrayView allocateMemory() {
-                return null;
-            }
-        }
 
         @Test
         public void testIfSlowPathIsChosenCorrectly() {

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/ExecutionDAGMockTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/ExecutionDAGMockTest.java
@@ -30,6 +30,11 @@
  */
 package com.nvidia.grcuda.test.runtime;
 
+import com.nvidia.grcuda.Type;
+import com.nvidia.grcuda.runtime.Kernel;
+import com.nvidia.grcuda.runtime.array.DeviceArray;
+import com.nvidia.grcuda.runtime.computation.ComputationArgument;
+import com.nvidia.grcuda.runtime.computation.ComputationArgumentWithValue;
 import com.nvidia.grcuda.runtime.computation.dependency.DependencyPolicyEnum;
 import com.nvidia.grcuda.runtime.executioncontext.AsyncGrCUDAExecutionContext;
 import com.nvidia.grcuda.runtime.executioncontext.ExecutionDAG;
@@ -38,9 +43,11 @@ import com.nvidia.grcuda.runtime.stream.RetrieveParentStreamPolicyEnum;
 import com.nvidia.grcuda.test.util.mock.ArgumentMock;
 import com.nvidia.grcuda.test.util.mock.AsyncGrCUDAExecutionContextMock;
 import com.nvidia.grcuda.test.util.mock.DeviceArrayMock;
+import com.nvidia.grcuda.test.util.mock.DeviceArrayWriteExecutionMock;
 import com.nvidia.grcuda.test.util.mock.GrCUDAExecutionContextMockBuilder;
 import com.nvidia.grcuda.test.util.mock.KernelExecutionMock;
 import com.nvidia.grcuda.test.util.mock.SyncExecutionMock;
+import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import org.junit.Test;
 
@@ -235,10 +242,12 @@ public class ExecutionDAGMockTest {
                 .setArchitecturePascalOrNewer(true).build();
 
         // This time, simulate a computation on the GPU, and a concurrent CPU read.
-        // As the array is not modified, there should be no dependency between them;
+        // As the array is not modified, there should be no dependency between them.
+        // However, we have to schedule the write to ensure that the GPU computation has finished before we update data;
         DeviceArrayMock x = new DeviceArrayMock(context);
         new KernelExecutionMock(context, Collections.singletonList(new ArgumentMock(x, true))).schedule();
-        assertTrue(x.canSkipScheduling());
+        assertTrue(x.canSkipSchedulingRead());
+        assertFalse(x.canSkipSchedulingWrite());
     }
 
     @Test
@@ -247,11 +256,12 @@ public class ExecutionDAGMockTest {
                 .setDependencyPolicy(DependencyPolicyEnum.WITH_CONST)
                 .setArchitecturePascalOrNewer(false).build();
 
-        // This time, simulate a computation on the GPU, and a concurrent CPU read.
+        // This time, simulate a computation on the GPU, and a concurrent CPU read & write.
         // As the GPU is pre-pascal, and we are running the kernel on the default stream, we must have a sync;
         DeviceArrayMock x = new DeviceArrayMock(context);
         new KernelExecutionMock(context, Collections.singletonList(new ArgumentMock(x, true))).schedule();
-        assertFalse(x.canSkipScheduling());
+        assertFalse(x.canSkipSchedulingRead());
+        assertFalse(x.canSkipSchedulingWrite());
     }
 
     @Test
@@ -260,10 +270,39 @@ public class ExecutionDAGMockTest {
                 .setDependencyPolicy(DependencyPolicyEnum.NO_CONST)
                 .setArchitecturePascalOrNewer(true).build();
 
-        // This time, simulate a computation on the GPU, and a concurrent CPU read.
+        // This time, simulate a computation on the GPU, and a concurrent CPU read & write.
         // As we are not considering "const", there should be a dependency;
         DeviceArrayMock x = new DeviceArrayMock(context);
         new KernelExecutionMock(context, Collections.singletonList(new ArgumentMock(x, true))).schedule();
-        assertFalse(x.canSkipScheduling());
+        assertFalse(x.canSkipSchedulingRead());
+        assertFalse(x.canSkipSchedulingWrite());
+    }
+
+    // Test that if we have a kernel that uses an array read-only, and we schedule a write on CPU,
+    // the scheduling of the write is not skipped and we have a dependency between the kernel and the write;
+    @Test
+    public void writeIsNotSkippedMockTest() throws UnsupportedTypeException, InvalidArrayIndexException {
+        AsyncGrCUDAExecutionContextMock context = new GrCUDAExecutionContextMockBuilder()
+                .setDependencyPolicy(DependencyPolicyEnum.WITH_CONST)
+                .setRetrieveNewStreamPolicy(RetrieveNewStreamPolicyEnum.FIFO)
+                .setRetrieveParentStreamPolicy(RetrieveParentStreamPolicyEnum.DISJOINT)
+                .setArchitecturePascalOrNewer(true).build();
+
+        DeviceArray array1 = new DeviceArrayMock(context);
+        ExecutionDAG dag = context.getDag();
+        // K1(const A1, A2);
+        KernelExecutionMock k = new KernelExecutionMock(context, Collections.singletonList(new ComputationArgumentWithValue("array1", Type.NFI_POINTER, ComputationArgument.Kind.POINTER_IN, array1)));
+        k.schedule();
+        assertEquals(2, array1.getArrayUpToDateLocations().size());
+        assertTrue(array1.isArrayUpdatedInLocation(0));
+        assertTrue(array1.isArrayUpdatedOnCPU());
+        // Write on the array;
+        array1.writeArrayElement(0, 0, null, null);
+        // Check that the array update status is tracked correctly;
+        assertEquals(1, array1.getArrayUpToDateLocations().size());
+        assertTrue(array1.isArrayUpdatedOnCPU());
+        // Check the existence of a dependency;
+        assertEquals(2, dag.getNumVertices());
+        assertEquals(1, dag.getNumEdges());
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/array/DeviceArrayLocationMockTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/array/DeviceArrayLocationMockTest.java
@@ -1,0 +1,54 @@
+package com.nvidia.grcuda.test.runtime.array;
+
+import com.nvidia.grcuda.runtime.CPUDevice;
+import com.nvidia.grcuda.runtime.array.DeviceArray;
+import com.nvidia.grcuda.test.util.mock.AsyncGrCUDAExecutionContextMock;
+import com.nvidia.grcuda.test.util.mock.DeviceArrayMock;
+import com.nvidia.grcuda.test.util.mock.GrCUDAExecutionContextMockBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DeviceArrayLocationMockTest {
+
+    @Test
+    public void testIfInitializedCorrectlyPrePascal() {
+        AsyncGrCUDAExecutionContextMock context = new GrCUDAExecutionContextMockBuilder().setArchitecturePascalOrNewer(false).build();
+        DeviceArray array1 = new DeviceArrayMock(context);
+        DeviceArray array2 = new DeviceArrayMock(context);
+        assertEquals(1, array1.getArrayUpToDateLocations().size());
+        assertEquals(1, array2.getArrayUpToDateLocations().size());
+        assertEquals(array1.getArrayUpToDateLocations(), array2.getArrayUpToDateLocations());
+        assertTrue(array1.getArrayUpToDateLocations().contains(context.currentGPU));
+    }
+
+    @Test
+    public void testIfInitializedCorrectlyPostPascal() {
+        AsyncGrCUDAExecutionContextMock context = new GrCUDAExecutionContextMockBuilder().setArchitecturePascalOrNewer(true).build();
+        DeviceArray array1 = new DeviceArrayMock(context);
+        DeviceArray array2 = new DeviceArrayMock(context);
+        assertEquals(1, array1.getArrayUpToDateLocations().size());
+        assertEquals(1, array2.getArrayUpToDateLocations().size());
+        assertEquals(array1.getArrayUpToDateLocations(), array2.getArrayUpToDateLocations());
+        assertTrue(array1.isArrayUpdatedInLocation(CPUDevice.CPU_DEVICE_ID));
+    }
+
+    @Test
+    public void testIfLocationAdded() {
+        AsyncGrCUDAExecutionContextMock context = new GrCUDAExecutionContextMockBuilder().setArchitecturePascalOrNewer(true).build();
+        DeviceArray array1 = new DeviceArrayMock(context);
+        array1.addArrayUpToDateLocations(2);
+        assertEquals(2, array1.getArrayUpToDateLocations().size());
+        assertTrue(array1.isArrayUpdatedInLocation(2));
+    }
+
+    @Test
+    public void testIfLocationReset() {
+        AsyncGrCUDAExecutionContextMock context = new GrCUDAExecutionContextMockBuilder().setArchitecturePascalOrNewer(true).build();
+        DeviceArray array1 = new DeviceArrayMock(context);
+        array1.resetArrayUpToDateLocations(2);
+        assertEquals(1, array1.getArrayUpToDateLocations().size());
+        assertTrue(array1.isArrayUpdatedInLocation(2));
+    }
+}

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/array/DeviceArrayLocationMockTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/array/DeviceArrayLocationMockTest.java
@@ -5,6 +5,7 @@ import com.nvidia.grcuda.runtime.array.DeviceArray;
 import com.nvidia.grcuda.runtime.array.MultiDimDeviceArray;
 import com.nvidia.grcuda.runtime.array.MultiDimDeviceArrayView;
 import com.nvidia.grcuda.runtime.computation.dependency.DependencyPolicyEnum;
+import com.nvidia.grcuda.runtime.executioncontext.ExecutionDAG;
 import com.nvidia.grcuda.runtime.stream.CUDAStream;
 import com.nvidia.grcuda.test.util.mock.ArgumentMock;
 import com.nvidia.grcuda.test.util.mock.AsyncGrCUDAExecutionContextMock;
@@ -18,6 +19,7 @@ import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/array/DeviceArrayLocationMockTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/array/DeviceArrayLocationMockTest.java
@@ -2,12 +2,25 @@ package com.nvidia.grcuda.test.runtime.array;
 
 import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.DeviceArray;
+import com.nvidia.grcuda.runtime.array.MultiDimDeviceArray;
+import com.nvidia.grcuda.runtime.array.MultiDimDeviceArrayView;
+import com.nvidia.grcuda.runtime.computation.dependency.DependencyPolicyEnum;
+import com.nvidia.grcuda.runtime.stream.CUDAStream;
+import com.nvidia.grcuda.test.util.mock.ArgumentMock;
 import com.nvidia.grcuda.test.util.mock.AsyncGrCUDAExecutionContextMock;
 import com.nvidia.grcuda.test.util.mock.DeviceArrayMock;
+import com.nvidia.grcuda.test.util.mock.DeviceArrayReadExecutionMock;
+import com.nvidia.grcuda.test.util.mock.DeviceArrayWriteExecutionMock;
 import com.nvidia.grcuda.test.util.mock.GrCUDAExecutionContextMockBuilder;
+import com.nvidia.grcuda.test.util.mock.KernelExecutionMock;
+import com.nvidia.grcuda.test.util.mock.MultiDimDeviceArrayMock;
+import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class DeviceArrayLocationMockTest {
@@ -20,7 +33,7 @@ public class DeviceArrayLocationMockTest {
         assertEquals(1, array1.getArrayUpToDateLocations().size());
         assertEquals(1, array2.getArrayUpToDateLocations().size());
         assertEquals(array1.getArrayUpToDateLocations(), array2.getArrayUpToDateLocations());
-        assertTrue(array1.getArrayUpToDateLocations().contains(context.currentGPU));
+        assertTrue(array1.getArrayUpToDateLocations().contains(AsyncGrCUDAExecutionContextMock.currentGPU));
     }
 
     @Test
@@ -50,5 +63,81 @@ public class DeviceArrayLocationMockTest {
         array1.resetArrayUpToDateLocations(2);
         assertEquals(1, array1.getArrayUpToDateLocations().size());
         assertTrue(array1.isArrayUpdatedInLocation(2));
+    }
+
+    @Test
+    public void testMultiDimLocation() {
+        AsyncGrCUDAExecutionContextMock context = new GrCUDAExecutionContextMockBuilder().setArchitecturePascalOrNewer(true).build();
+
+        long[] dimensions = {2, 2};
+        MultiDimDeviceArray array1 = new MultiDimDeviceArrayMock(context, dimensions, false);
+        assertTrue(array1.isArrayUpdatedOnCPU());
+        array1.addArrayUpToDateLocations(2);
+        array1.addArrayUpToDateLocations(3);
+        assertEquals(3, array1.getArrayUpToDateLocations().size());
+        // Create a view, parameters don't matter;
+        MultiDimDeviceArrayView view = new MultiDimDeviceArrayView(array1, 1, 0, 0);
+        assertEquals(array1.getArrayUpToDateLocations(), view.getArrayUpToDateLocations());
+        // Add a location to the view, check that it is propagated;
+        view.addArrayUpToDateLocations(4);
+        assertEquals(4, view.getArrayUpToDateLocations().size());
+        assertEquals(array1.getArrayUpToDateLocations(), view.getArrayUpToDateLocations());
+        // Reset locations on the view, check that the parent is updated;
+        view.resetArrayUpToDateLocations(10);
+        assertEquals(1, view.getArrayUpToDateLocations().size());
+        assertEquals(array1.getArrayUpToDateLocations(), view.getArrayUpToDateLocations());
+        // Reset locations on the parent, check that the view is updated;
+        array1.resetArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        assertEquals(1, view.getArrayUpToDateLocations().size());
+        assertTrue(view.isArrayUpdatedOnCPU());
+        assertTrue(view.isArrayUpdatedInLocation(CPUDevice.CPU_DEVICE_ID));
+        assertEquals(array1.getArrayUpToDateLocations(), view.getArrayUpToDateLocations());
+        // Reset locations on the view (again), but also on the parent, and check consistency;
+        view.resetArrayUpToDateLocations(10);
+        array1.addArrayUpToDateLocations(2);
+        assertEquals(2, view.getArrayUpToDateLocations().size());
+        assertEquals(array1.getArrayUpToDateLocations(), view.getArrayUpToDateLocations());
+    }
+
+    @Test
+    public void complexFrontierWithSyncMockTest() throws UnsupportedTypeException {
+        AsyncGrCUDAExecutionContextMock context = new GrCUDAExecutionContextMockBuilder()
+                .setDependencyPolicy(DependencyPolicyEnum.WITH_CONST)
+                .setArchitecturePascalOrNewer(true).build();
+
+        DeviceArray array1 = new DeviceArrayMock(context);
+        DeviceArray array2 = new DeviceArrayMock(context);
+        DeviceArray array3 = new DeviceArrayMock(context);
+        // K1(const A1, A2);
+        new KernelExecutionMock(context, Arrays.asList(new ArgumentMock(array1, true), new ArgumentMock(array2, false))).schedule();
+        assertEquals(2, array1.getArrayUpToDateLocations().size());
+        assertTrue(array1.isArrayUpdatedInLocation(0));
+        assertTrue(array1.isArrayUpdatedOnCPU());
+        assertEquals(1, array2.getArrayUpToDateLocations().size());
+        assertTrue(array2.isArrayUpdatedInLocation(0));
+        // Set another GPU;
+        // K2(const A1, A3);
+        context.setCurrentGPU(1);
+        KernelExecutionMock k2 = new KernelExecutionMock(context, Arrays.asList(new ArgumentMock(array1, true), new ArgumentMock(array3, false)));
+        k2.setStream(new CUDAStream(0, 0, context.getCurrentGPU()));
+        k2.schedule();
+        assertEquals(3, array1.getArrayUpToDateLocations().size());
+        assertTrue(array1.isArrayUpdatedInLocation(1));
+        assertEquals(1, array3.getArrayUpToDateLocations().size());
+        assertTrue(array3.isArrayUpdatedInLocation(1));
+        assertEquals(1, array2.getArrayUpToDateLocations().size());  // A2 is unmodified;
+        assertTrue(array2.isArrayUpdatedInLocation(0));
+        // Write on 2 arrays, read on another array. The CPU will be the exclusive owner of the first 2 arrays,
+        // and share with GPU 0 the other array;
+        new DeviceArrayWriteExecutionMock(array1, 0, 0).schedule();
+        new DeviceArrayReadExecutionMock(array2, 0).schedule();
+        new DeviceArrayWriteExecutionMock(array3, 0, 0).schedule();
+        assertEquals(1, array1.getArrayUpToDateLocations().size());
+        assertTrue(array1.isArrayUpdatedOnCPU());
+        assertEquals(1, array3.getArrayUpToDateLocations().size());
+        assertTrue(array3.isArrayUpdatedOnCPU());
+        assertEquals(2, array2.getArrayUpToDateLocations().size());
+        assertTrue(array2.isArrayUpdatedOnCPU());
+        assertTrue(array2.isArrayUpdatedInLocation(0));
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/array/MultiDimArrayTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/array/MultiDimArrayTest.java
@@ -152,6 +152,7 @@ public class MultiDimArrayTest {
             final int numDim3 = 2;
             Value matrix = deviceArrayConstructor.execute("int", numDim1, numDim2, numDim3, "F");
             assertEquals(numDim1, matrix.getArraySize());
+            Value a = matrix.getArrayElement(0);
             assertEquals(numDim2, matrix.getArrayElement(0).getArraySize());
             assertEquals(numDim3, matrix.getArrayElement(0).getArrayElement(0).getArraySize());
             for (int i = 0; i < numDim1; i++) {

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/executioncontext/GrCUDAExecutionContextTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/runtime/executioncontext/GrCUDAExecutionContextTest.java
@@ -31,6 +31,7 @@
 package com.nvidia.grcuda.test.runtime.executioncontext;
 
 import com.nvidia.grcuda.runtime.executioncontext.AsyncGrCUDAExecutionContext;
+import com.nvidia.grcuda.runtime.executioncontext.ExecutionPolicyEnum;
 import com.nvidia.grcuda.test.util.GrCUDATestOptionsStruct;
 import com.nvidia.grcuda.test.util.GrCUDATestUtil;
 import org.graalvm.polyglot.Context;
@@ -109,6 +110,46 @@ public class GrCUDAExecutionContextTest {
                     "        atomicAdd(res, cache[0]);\n" +
                     "    }\n" +
                     "}";
+
+//    private static final String TEST_KERNEL =
+//            "extern \"C\" __global__ void test(const int* x, int n) {\n" +
+//                    "   int sum = 0;\n" +
+//                    "   for (int i = 0; i < n * n; i++) {\n" +
+//                    "       sum += x[i / n];\n" +
+//                    "   }\n" +
+//                    "   printf(\"gpu res: %d\\n\", &sum);\n" +
+//                    "}";
+
+//    @Test
+//    public void test() {
+//        try (Context context = GrCUDATestUtil.createContextFromOptions(this.options)) {
+//            if (options.policy.equals(ExecutionPolicyEnum.ASYNC)) {
+//                System.out.println(options);
+//                final int numElements = 10000;
+//                final int numBlocks = 1;
+//                Value deviceArrayConstructor = context.eval("grcuda", "DeviceArray");
+//                Value x = deviceArrayConstructor.execute("float", numElements);
+//                Value buildkernel = context.eval("grcuda", "buildkernel");
+//                Value testKernel = buildkernel.execute(TEST_KERNEL, "test", "const pointer, sint32");
+//
+//                assertNotNull(testKernel);
+//
+//                for (int i = 0; i < numElements; ++i) {
+//                    x.setArrayElement(i, 1);
+//                }
+//
+//                Value configuredKernel = testKernel.execute(numBlocks, 1);
+//
+//                // Perform the computation;
+//                configuredKernel.execute(x, numElements);
+//                System.out.println(x.getArrayElement(0));
+//                System.out.println(x.getArrayElement(1));
+//
+//                // Verify the output;
+//                assertEquals(1, x.getArrayElement(1).asInt());
+//            }
+//        }
+//    }
 
     @Test
     public void dependencyKernelSimpleTest() {

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/AsyncGrCUDAExecutionContextMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/AsyncGrCUDAExecutionContextMock.java
@@ -52,7 +52,7 @@ public class AsyncGrCUDAExecutionContextMock extends AsyncGrCUDAExecutionContext
 
     // Store it here to avoid using a mocked runtime;
     private final boolean architectureIsPascalOrNewer;
-    public int currentGPU = 0;
+    public static int currentGPU = 0;
 
     public void setCurrentGPU(int gpu) {
         currentGPU = gpu;

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/AsyncGrCUDAExecutionContextMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/AsyncGrCUDAExecutionContextMock.java
@@ -34,6 +34,7 @@ import com.nvidia.grcuda.GrCUDAOptionMap;
 import com.nvidia.grcuda.GrCUDAOptions;
 import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.AbstractArray;
+import com.nvidia.grcuda.runtime.computation.streamattach.PostPascalStreamAttachPolicy;
 import com.nvidia.grcuda.runtime.computation.streamattach.StreamAttachArchitecturePolicy;
 import com.nvidia.grcuda.runtime.computation.streamattach.PrePascalStreamAttachPolicy;
 import com.nvidia.grcuda.runtime.computation.dependency.DependencyPolicyEnum;
@@ -50,7 +51,7 @@ public class AsyncGrCUDAExecutionContextMock extends AsyncGrCUDAExecutionContext
     // FIXME: handling current GPU etc. should be done with a mocked device manager;
 
     // Store it here to avoid using a mocked runtime;
-    public final boolean architectureIsPascalOrNewer;
+    private final boolean architectureIsPascalOrNewer;
     public int currentGPU = 0;
 
     public void setCurrentGPU(int gpu) {
@@ -98,15 +99,11 @@ public class AsyncGrCUDAExecutionContextMock extends AsyncGrCUDAExecutionContext
     }
 
     public StreamAttachArchitecturePolicy getArrayStreamArchitecturePolicy() {
-        return new PrePascalStreamAttachPolicy();
+        return architectureIsPascalOrNewer ? new PrePascalStreamAttachPolicy() : new PostPascalStreamAttachPolicy();
     }
 
     @Override
-    public void initializeArrayLocation(AbstractArray array) {
-        if (architectureIsPascalOrNewer) {
-            array.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
-        } else {
-            array.addArrayUpToDateLocations(currentGPU);
-        }
+    public boolean isArchitecturePascalOrNewer() {
+        return architectureIsPascalOrNewer;
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/AsyncGrCUDAExecutionContextMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/AsyncGrCUDAExecutionContextMock.java
@@ -62,16 +62,12 @@ public class AsyncGrCUDAExecutionContextMock extends AsyncGrCUDAExecutionContext
     }
 
     public AsyncGrCUDAExecutionContextMock() {
-        this(true);
-    }
-
-    public AsyncGrCUDAExecutionContextMock(boolean architectureIsPascalOrNewer) {
         super(null,
                 new GrCUDAOptionMap(new OptionValuesMockBuilder()
                         .add(GrCUDAOptions.DependencyPolicy, DependencyPolicyEnum.NO_CONST.toString())
                         .add(GrCUDAOptions.InputPrefetch, false).build()),
                 new GrCUDAStreamManagerMock(null));
-        this.architectureIsPascalOrNewer = architectureIsPascalOrNewer;
+        this.architectureIsPascalOrNewer = true;
     }
 
     public AsyncGrCUDAExecutionContextMock(DependencyPolicyEnum dependencyPolicy) {

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/AsyncGrCUDAExecutionContextMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/AsyncGrCUDAExecutionContextMock.java
@@ -32,6 +32,8 @@ package com.nvidia.grcuda.test.util.mock;
 
 import com.nvidia.grcuda.GrCUDAOptionMap;
 import com.nvidia.grcuda.GrCUDAOptions;
+import com.nvidia.grcuda.runtime.CPUDevice;
+import com.nvidia.grcuda.runtime.array.AbstractArray;
 import com.nvidia.grcuda.runtime.computation.streamattach.StreamAttachArchitecturePolicy;
 import com.nvidia.grcuda.runtime.computation.streamattach.PrePascalStreamAttachPolicy;
 import com.nvidia.grcuda.runtime.computation.dependency.DependencyPolicyEnum;
@@ -45,12 +47,31 @@ import com.nvidia.grcuda.runtime.stream.RetrieveParentStreamPolicyEnum;
  */
 public class AsyncGrCUDAExecutionContextMock extends AsyncGrCUDAExecutionContext {
 
+    // FIXME: handling current GPU etc. should be done with a mocked device manager;
+
+    // Store it here to avoid using a mocked runtime;
+    public final boolean architectureIsPascalOrNewer;
+    public int currentGPU = 0;
+
+    public void setCurrentGPU(int gpu) {
+        currentGPU = gpu;
+    }
+
+    public int getCurrentGPU() {
+        return currentGPU;
+    }
+
     public AsyncGrCUDAExecutionContextMock() {
+        this(true);
+    }
+
+    public AsyncGrCUDAExecutionContextMock(boolean architectureIsPascalOrNewer) {
         super(null,
                 new GrCUDAOptionMap(new OptionValuesMockBuilder()
                         .add(GrCUDAOptions.DependencyPolicy, DependencyPolicyEnum.NO_CONST.toString())
                         .add(GrCUDAOptions.InputPrefetch, false).build()),
                 new GrCUDAStreamManagerMock(null));
+        this.architectureIsPascalOrNewer = architectureIsPascalOrNewer;
     }
 
     public AsyncGrCUDAExecutionContextMock(DependencyPolicyEnum dependencyPolicy) {
@@ -59,19 +80,37 @@ public class AsyncGrCUDAExecutionContextMock extends AsyncGrCUDAExecutionContext
                         .add(GrCUDAOptions.DependencyPolicy, dependencyPolicy.toString())
                         .add(GrCUDAOptions.InputPrefetch, false).build()),
                 new GrCUDAStreamManagerMock(null));
+        this.architectureIsPascalOrNewer = true;
     }
 
     public AsyncGrCUDAExecutionContextMock(DependencyPolicyEnum dependencyPolicy,
                                            RetrieveNewStreamPolicyEnum retrieveStreamPolicy,
                                            RetrieveParentStreamPolicyEnum parentStreamPolicyEnum) {
+        this(dependencyPolicy, retrieveStreamPolicy, parentStreamPolicyEnum,true);
+    }
+
+    public AsyncGrCUDAExecutionContextMock(DependencyPolicyEnum dependencyPolicy,
+                                           RetrieveNewStreamPolicyEnum retrieveStreamPolicy,
+                                           RetrieveParentStreamPolicyEnum parentStreamPolicyEnum,
+                                           boolean architectureIsPascalOrNewer) {
         super(null,
                 new GrCUDAOptionMap(new OptionValuesMockBuilder()
                         .add(GrCUDAOptions.DependencyPolicy, dependencyPolicy.toString())
                         .add(GrCUDAOptions.InputPrefetch, false).build()),
                 new GrCUDAStreamManagerMock(null, retrieveStreamPolicy, parentStreamPolicyEnum));
+        this.architectureIsPascalOrNewer = architectureIsPascalOrNewer;
     }
 
     public StreamAttachArchitecturePolicy getArrayStreamArchitecturePolicy() {
         return new PrePascalStreamAttachPolicy();
+    }
+
+    @Override
+    public void initializeArrayLocation(AbstractArray array) {
+        if (architectureIsPascalOrNewer) {
+            array.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        } else {
+            array.addArrayUpToDateLocations(currentGPU);
+        }
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayMock.java
@@ -1,6 +1,7 @@
 package com.nvidia.grcuda.test.util.mock;
 
 import com.nvidia.grcuda.Type;
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.LittleEndianNativeArrayView;
 import com.nvidia.grcuda.runtime.array.DeviceArray;
 import com.nvidia.grcuda.runtime.executioncontext.AbstractGrCUDAExecutionContext;
@@ -12,6 +13,11 @@ public class DeviceArrayMock extends DeviceArray {
 
     public DeviceArrayMock(AbstractGrCUDAExecutionContext context) {
         super(context, 0, Type.SINT32);
+        if (context.isArchitecturePascalOrNewer()) {
+            this.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        } else {
+            this.addArrayUpToDateLocations(context.getCurrentGPU());
+        }
     }
 
     @Override

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayMock.java
@@ -1,10 +1,21 @@
 package com.nvidia.grcuda.test.util.mock;
 
+import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.Type;
 import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.LittleEndianNativeArrayView;
+import com.nvidia.grcuda.runtime.array.AbstractArray;
 import com.nvidia.grcuda.runtime.array.DeviceArray;
+import com.nvidia.grcuda.runtime.computation.arraycomputation.DeviceArrayWriteExecution;
 import com.nvidia.grcuda.runtime.executioncontext.AbstractGrCUDAExecutionContext;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.InvalidArrayIndexException;
+import com.oracle.truffle.api.interop.UnsupportedTypeException;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.profiles.ValueProfile;
 
 public class DeviceArrayMock extends DeviceArray {
     public DeviceArrayMock() {
@@ -17,6 +28,17 @@ public class DeviceArrayMock extends DeviceArray {
             this.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
         } else {
             this.addArrayUpToDateLocations(context.getCurrentGPU());
+        }
+    }
+
+    @Override
+    public void writeArrayElement(long index, Object value,
+                                  @CachedLibrary(limit = "3") InteropLibrary valueLibrary,
+                                  @Cached.Shared("elementType") @Cached("createIdentityProfile()") ValueProfile elementTypeProfile) throws UnsupportedTypeException, InvalidArrayIndexException {
+        if (this.canSkipSchedulingWrite()) {
+            // Fast path, don't do anything here;
+        } else {
+            new DeviceArrayWriteExecutionMock(this, index, value).schedule();
         }
     }
 

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayMock.java
@@ -1,0 +1,22 @@
+package com.nvidia.grcuda.test.util.mock;
+
+import com.nvidia.grcuda.Type;
+import com.nvidia.grcuda.runtime.LittleEndianNativeArrayView;
+import com.nvidia.grcuda.runtime.array.DeviceArray;
+import com.nvidia.grcuda.runtime.executioncontext.AbstractGrCUDAExecutionContext;
+
+public class DeviceArrayMock extends DeviceArray {
+    public DeviceArrayMock() {
+        super(new AsyncGrCUDAExecutionContextMock(), 0, Type.SINT32);
+    }
+
+    public DeviceArrayMock(AbstractGrCUDAExecutionContext context) {
+        super(context, 0, Type.SINT32);
+    }
+
+    @Override
+    protected LittleEndianNativeArrayView allocateMemory() {
+        return null;
+    }
+}
+

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayReadExecutionMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayReadExecutionMock.java
@@ -28,28 +28,43 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.nvidia.grcuda.runtime.computation.arraycomputation;
+package com.nvidia.grcuda.test.util.mock;
 
-import com.nvidia.grcuda.runtime.array.AbstractArray;
-import com.nvidia.grcuda.runtime.computation.GrCUDAComputationalElement;
-import com.nvidia.grcuda.runtime.computation.InitializeDependencyList;
-import com.nvidia.grcuda.runtime.executioncontext.AbstractGrCUDAExecutionContext;
-import com.nvidia.grcuda.runtime.stream.CUDAStream;
+import java.util.stream.Collectors;
 
-import java.util.Optional;
+import com.nvidia.grcuda.NoneValue;
+import com.nvidia.grcuda.runtime.array.DeviceArray;
+import com.nvidia.grcuda.runtime.computation.arraycomputation.DeviceArrayReadExecution;
+import com.nvidia.grcuda.runtime.computation.arraycomputation.DeviceArrayWriteExecution;
 
 /**
- * Abstract class that wraps all computational elements representing accesses on managed memory by the CPU;
+ * Mock class that represents a synchronous read execution,
+ * it can be used to synchronize previous computations using the specified arguments;
  */
-public abstract class ArrayAccessExecution<T extends AbstractArray> extends GrCUDAComputationalElement {
+public class DeviceArrayReadExecutionMock extends DeviceArrayReadExecution {
 
-    protected T array;
-
-    public ArrayAccessExecution(AbstractGrCUDAExecutionContext grCUDAExecutionContext, InitializeDependencyList initializer, T array) {
-        super(grCUDAExecutionContext, initializer);
-        this.array = array;
+    public DeviceArrayReadExecutionMock(DeviceArray array,
+                                        long index) {
+        super(array, index, null);
     }
 
     @Override
-    protected Optional<CUDAStream> additionalStreamDependencyImpl() { return Optional.of(array.getStreamMapping()); }
+    public Object execute() {
+        this.setComputationFinished();
+        return NoneValue.get();
+    }
+
+    @Override
+    public boolean canUseStream() { return false; }
+
+    @Override
+    public void associateArraysToStreamImpl() { }
+
+    @Override
+    public String toString() {
+        return "sync read" + "; args=[" +
+                this.argumentList.stream().map(Object::toString).collect(Collectors.joining(", ")) +
+                "]";
+    }
 }
+

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayReadExecutionMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayReadExecutionMock.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import com.nvidia.grcuda.NoneValue;
 import com.nvidia.grcuda.runtime.array.DeviceArray;
 import com.nvidia.grcuda.runtime.computation.arraycomputation.DeviceArrayReadExecution;
-import com.nvidia.grcuda.runtime.computation.arraycomputation.DeviceArrayWriteExecution;
 
 /**
  * Mock class that represents a synchronous read execution,
@@ -63,7 +62,7 @@ public class DeviceArrayReadExecutionMock extends DeviceArrayReadExecution {
     @Override
     public String toString() {
         return "sync read" + "; args=[" +
-                this.argumentList.stream().map(Object::toString).collect(Collectors.joining(", ")) +
+                this.argumentsThatCanCreateDependencies.stream().map(Object::toString).collect(Collectors.joining(", ")) +
                 "]";
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayWriteExecutionMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayWriteExecutionMock.java
@@ -28,28 +28,42 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.nvidia.grcuda.runtime.computation.arraycomputation;
+package com.nvidia.grcuda.test.util.mock;
 
-import com.nvidia.grcuda.runtime.array.AbstractArray;
-import com.nvidia.grcuda.runtime.computation.GrCUDAComputationalElement;
-import com.nvidia.grcuda.runtime.computation.InitializeDependencyList;
-import com.nvidia.grcuda.runtime.executioncontext.AbstractGrCUDAExecutionContext;
-import com.nvidia.grcuda.runtime.stream.CUDAStream;
+import java.util.stream.Collectors;
 
-import java.util.Optional;
+import com.nvidia.grcuda.NoneValue;
+import com.nvidia.grcuda.runtime.array.DeviceArray;
+import com.nvidia.grcuda.runtime.computation.arraycomputation.DeviceArrayWriteExecution;
 
 /**
- * Abstract class that wraps all computational elements representing accesses on managed memory by the CPU;
+ * Mock class that represents a synchronous write execution,
+ * it can be used to synchronize previous computations using the specified arguments;
  */
-public abstract class ArrayAccessExecution<T extends AbstractArray> extends GrCUDAComputationalElement {
+public class DeviceArrayWriteExecutionMock extends DeviceArrayWriteExecution {
 
-    protected T array;
-
-    public ArrayAccessExecution(AbstractGrCUDAExecutionContext grCUDAExecutionContext, InitializeDependencyList initializer, T array) {
-        super(grCUDAExecutionContext, initializer);
-        this.array = array;
+    public DeviceArrayWriteExecutionMock(DeviceArray array,
+                                         long index,
+                                         Object value) {
+        super(array, index, value, null, null);
     }
 
     @Override
-    protected Optional<CUDAStream> additionalStreamDependencyImpl() { return Optional.of(array.getStreamMapping()); }
+    public Object execute() {
+        this.setComputationFinished();
+        return NoneValue.get();
+    }
+
+    @Override
+    public boolean canUseStream() { return false; }
+
+    @Override
+    public void associateArraysToStreamImpl() { }
+
+    @Override
+    public String toString() {
+        return "sync write" + "; args=[" +
+                this.argumentList.stream().map(Object::toString).collect(Collectors.joining(", ")) +
+                "]";
+    }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayWriteExecutionMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/DeviceArrayWriteExecutionMock.java
@@ -63,7 +63,7 @@ public class DeviceArrayWriteExecutionMock extends DeviceArrayWriteExecution {
     @Override
     public String toString() {
         return "sync write" + "; args=[" +
-                this.argumentList.stream().map(Object::toString).collect(Collectors.joining(", ")) +
+                this.argumentsThatCanCreateDependencies.stream().map(Object::toString).collect(Collectors.joining(", ")) +
                 "]";
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/GrCUDAExecutionContextMockBuilder.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/GrCUDAExecutionContextMockBuilder.java
@@ -39,9 +39,10 @@ public class GrCUDAExecutionContextMockBuilder {
     DependencyPolicyEnum dependencyPolicy = DependencyPolicyEnum.NO_CONST;
     RetrieveNewStreamPolicyEnum retrieveStreamPolicy = RetrieveNewStreamPolicyEnum.FIFO;
     RetrieveParentStreamPolicyEnum parentStreamPolicyEnum = RetrieveParentStreamPolicyEnum.SAME_AS_PARENT;
+    boolean isArchitecturePascalOrNewer = true;
 
     public AsyncGrCUDAExecutionContextMock build() {
-        return new AsyncGrCUDAExecutionContextMock(dependencyPolicy, retrieveStreamPolicy, parentStreamPolicyEnum);
+        return new AsyncGrCUDAExecutionContextMock(dependencyPolicy, retrieveStreamPolicy, parentStreamPolicyEnum, isArchitecturePascalOrNewer);
     }
 
     public GrCUDAExecutionContextMockBuilder setDependencyPolicy(DependencyPolicyEnum dependencyPolicy) {
@@ -56,6 +57,11 @@ public class GrCUDAExecutionContextMockBuilder {
 
     public GrCUDAExecutionContextMockBuilder setRetrieveParentStreamPolicy(RetrieveParentStreamPolicyEnum retrieveStreamPolicy) {
         this.parentStreamPolicyEnum = retrieveStreamPolicy;
+        return this;
+    }
+
+    public GrCUDAExecutionContextMockBuilder setArchitecturePascalOrNewer(boolean isArchitecturePascalOrNewer) {
+        this.isArchitecturePascalOrNewer = isArchitecturePascalOrNewer;
         return this;
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/GrCUDAStreamManagerMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/GrCUDAStreamManagerMock.java
@@ -60,7 +60,8 @@ public class GrCUDAStreamManagerMock extends GrCUDAStreamManager {
 
     @Override
     public CUDAStream createStream() {
-        CUDAStream newStream = new CUDAStream(0, numStreams++, 0);
+        // FIXME: we really need a mocked runtime to avoid using a static variable!
+        CUDAStream newStream = new CUDAStream(0, numStreams++, AsyncGrCUDAExecutionContextMock.currentGPU);
         streams.add(newStream);
         return newStream;
     }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/KernelExecutionMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/KernelExecutionMock.java
@@ -79,7 +79,7 @@ public class KernelExecutionMock extends GrCUDAComputationalElement {
     @Override
     public String toString() {
         return "kernel mock" + "; args=[" +
-                this.argumentList.stream().map(Object::toString).collect(Collectors.joining(", ")) +
+                this.argumentsThatCanCreateDependencies.stream().map(Object::toString).collect(Collectors.joining(", ")) +
                 "]" + "; stream=" + this.getStream().getStreamNumber();
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/MultiDimDeviceArrayMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/MultiDimDeviceArrayMock.java
@@ -1,12 +1,23 @@
 package com.nvidia.grcuda.test.util.mock;
 
 import com.nvidia.grcuda.Type;
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.LittleEndianNativeArrayView;
 import com.nvidia.grcuda.runtime.array.MultiDimDeviceArray;
+import com.nvidia.grcuda.runtime.executioncontext.AbstractGrCUDAExecutionContext;
 
 public class MultiDimDeviceArrayMock extends MultiDimDeviceArray {
     public MultiDimDeviceArrayMock(long[] dimensions, boolean columnMajor) {
         super(new AsyncGrCUDAExecutionContextMock(), Type.SINT32, dimensions, columnMajor);
+    }
+
+    public MultiDimDeviceArrayMock(AbstractGrCUDAExecutionContext context, long[] dimensions, boolean columnMajor) {
+        super(context,  Type.SINT32, dimensions, columnMajor);
+        if (context.isArchitecturePascalOrNewer()) {
+            this.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        } else {
+            this.addArrayUpToDateLocations(context.getCurrentGPU());
+        }
     }
 
     @Override

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/MultiDimDeviceArrayMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/MultiDimDeviceArrayMock.java
@@ -1,0 +1,16 @@
+package com.nvidia.grcuda.test.util.mock;
+
+import com.nvidia.grcuda.Type;
+import com.nvidia.grcuda.runtime.LittleEndianNativeArrayView;
+import com.nvidia.grcuda.runtime.array.MultiDimDeviceArray;
+
+public class MultiDimDeviceArrayMock extends MultiDimDeviceArray {
+    public MultiDimDeviceArrayMock(long[] dimensions, boolean columnMajor) {
+        super(new AsyncGrCUDAExecutionContextMock(), Type.SINT32, dimensions, columnMajor);
+    }
+
+    @Override
+    protected LittleEndianNativeArrayView allocateMemory() {
+        return null;
+    }
+}

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/SyncExecutionMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/SyncExecutionMock.java
@@ -63,7 +63,7 @@ public class SyncExecutionMock extends GrCUDAComputationalElement {
     @Override
     public String toString() {
         return "sync" + "; args=[" +
-                this.argumentList.stream().map(Object::toString).collect(Collectors.joining(", ")) +
+                this.argumentsThatCanCreateDependencies.stream().map(Object::toString).collect(Collectors.joining(", ")) +
                 "]";
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/AbstractDevice.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/AbstractDevice.java
@@ -1,0 +1,35 @@
+package com.nvidia.grcuda.runtime;
+
+/**
+ * Abstract device representation, used to distinguish between CPU and GPU devices inside the GrCUDA scheduler.
+ */
+public class AbstractDevice {
+    protected final int deviceId;
+
+    public AbstractDevice(int deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public int getDeviceId() {
+        return deviceId;
+    }
+
+    @Override
+    public String toString() {
+        return "Device(id=" + deviceId + ")";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof AbstractDevice) {
+            AbstractDevice otherDevice = (AbstractDevice) other;
+            return otherDevice.deviceId == deviceId;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return deviceId;
+    }
+}

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CPUDevice.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CPUDevice.java
@@ -1,0 +1,14 @@
+package com.nvidia.grcuda.runtime;
+
+public class CPUDevice extends AbstractDevice {
+    public static final int CPU_DEVICE_ID = -1;
+
+    public CPUDevice() {
+        super(CPU_DEVICE_ID);
+    }
+
+    @Override
+    public String toString() {
+        return "CPU(id=" + deviceId + ")";
+    }
+}

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CUDARuntime.java
@@ -99,6 +99,10 @@ public final class CUDARuntime {
      */
     private int numberOfGPUsToUse = GrCUDAOptionMap.DEFAULT_NUMBER_OF_GPUs;
 
+    public int getNumberOfGPUsToUse() {
+        return numberOfGPUsToUse;
+    }
+
     /**
      * Identifier of the GPU that is currently active;
      */

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/Device.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/Device.java
@@ -35,6 +35,7 @@
  */
 package com.nvidia.grcuda.runtime;
 
+import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.MemberSet;
 import com.nvidia.grcuda.NoneValue;
 import com.oracle.truffle.api.CompilerDirectives;
@@ -51,23 +52,23 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.profiles.ValueProfile;
 
-// TODO: we assume that all devices are GPUs. It might make sense to have an "abstract device" from which we inherit CPUDevice and GPUDevice (this class),
-//  and have "deviceId" as parameter of the class;
 
 @ExportLibrary(InteropLibrary.class)
-public final class Device implements TruffleObject {
+public final class Device extends AbstractDevice implements TruffleObject {
 
     private static final String ID = "id";
     private static final String PROPERTIES = "properties";
     private static final String IS_CURRENT = "isCurrent";
     private static final String SET_CURRENT = "setCurrent";
     private static final MemberSet PUBLIC_MEMBERS = new MemberSet(ID, PROPERTIES, IS_CURRENT, SET_CURRENT);
-    private final int deviceId;
     private final GPUDeviceProperties properties;
     private final CUDARuntime runtime;
 
     public Device(int deviceId, CUDARuntime runtime) {
-        this.deviceId = deviceId;
+        super(deviceId);
+        if (deviceId < 0) {
+            throw new GrCUDAException("GPU device must have id > 0, instead it is " + deviceId);
+        }
         this.runtime = runtime;
         this.properties = new GPUDeviceProperties(deviceId, runtime);
     }
@@ -82,7 +83,7 @@ public final class Device implements TruffleObject {
 
     @Override
     public String toString() {
-        return "Device(id=" + deviceId + ")";
+        return "GPU(id=" + deviceId + ")";
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/GPUDeviceProperties.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/GPUDeviceProperties.java
@@ -175,7 +175,6 @@ public final class GPUDeviceProperties implements TruffleObject {
         String getName();
 
         Object getValue(int deviceId, CUDARuntime runtime);
-
     }
 
     private static class DeviceAttributeProperty implements DeviceProperty {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/AbstractArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/AbstractArray.java
@@ -183,6 +183,10 @@ public abstract class AbstractArray implements TruffleObject {
      * for array accesses that are immediately following the last one, as they are performed synchronously and there is no
      * reason to explicitly model them in the {@link ExecutionDAG};
      */
+    // FIXME: Possible error: Array A is up-to-date on CPU and GPU0. There's an ongoing kernel on GPU0 that uses A read-only.
+    //  If we write A on the CPU, is the scheduling skipped? That's an error.
+    //  In the case of a read, no problem (a kernel that modifies the data would take exclusive ownership),
+    //  while in the case of a write we need to check that arrayUpToDateLocations == CPU
     public boolean isArrayUpdatedOnCPU() {
         return this.arrayUpToDateLocations.contains(CPUDevice.CPU_DEVICE_ID);
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/AbstractArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/AbstractArray.java
@@ -182,6 +182,15 @@ public abstract class AbstractArray implements TruffleObject {
         this.arrayUpToDateLocations.add(deviceId);
     }
 
+    /**
+     * True if this array is up-to-date for the input device;
+     * @param deviceId a device for which we want to check if this array is up-to-date;
+     * @return if this array is up-to-date with respect to the input device
+     */
+    public boolean isArrayUpdatedInLocation(int deviceId) {
+        return this.arrayUpToDateLocations.contains(deviceId);
+    }
+
     public abstract long getPointer();
     public abstract long getSizeBytes();
     public abstract void freeMemory();

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/AbstractArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/AbstractArray.java
@@ -35,6 +35,8 @@ import com.nvidia.grcuda.MemberSet;
 import com.nvidia.grcuda.NoneValue;
 import com.nvidia.grcuda.Type;
 import com.nvidia.grcuda.functions.DeviceArrayCopyFunction;
+import com.nvidia.grcuda.runtime.AbstractDevice;
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.LittleEndianNativeArrayView;
 import com.nvidia.grcuda.runtime.computation.arraycomputation.ArrayAccessExecution;
 import com.nvidia.grcuda.runtime.executioncontext.AbstractGrCUDAExecutionContext;
@@ -42,8 +44,6 @@ import com.nvidia.grcuda.runtime.executioncontext.ExecutionDAG;
 import com.nvidia.grcuda.runtime.stream.CUDAStream;
 import com.nvidia.grcuda.runtime.stream.DefaultStream;
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.Truffle;
-import com.oracle.truffle.api.TruffleRuntime;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -56,6 +56,9 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.profiles.ValueProfile;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Simple wrapper around each class that represents device arrays in GrCUDA.
@@ -89,6 +92,7 @@ public abstract class AbstractArray implements TruffleObject {
      * Used to avoid multiple registration;
      */
     private boolean registeredInContext = false;
+
     /**
      * Keep track of whether this array is attached to a specific stream that limits its visibility.
      * By default, every array is attached to the {@link DefaultStream};
@@ -101,10 +105,17 @@ public abstract class AbstractArray implements TruffleObject {
      * for array accesses that are immediately following the last one, as they are performed synchronously and there is no
      * reason to explicitly model them in the {@link ExecutionDAG};
      */
-    private boolean isLastComputationArrayAccess = true;
+    private boolean isLastComputationCPUAccess;
 
     /** Flag set when underlying off-heap memory has been freed. */
     protected boolean arrayFreed = false;
+
+    /**
+     * List of devices where the array is currently UP-TO-DATE, i.e. it can be accessed without requiring any memory transfer.
+     * On pre-Pascal GPUs, arrays are allocated on the currently active GPU. On devices since Pascal, arrays are allocated on the CPU.
+     * We identify devices using integers. CPU is -1 ({@link com.nvidia.grcuda.runtime.CPUDevice#CPU_DEVICE_ID}, GPUs start from 0;
+     */
+    private final Set<Integer> arrayUpToDateLocations = new HashSet<>();
 
     public Type getElementType() {
         return elementType;
@@ -114,10 +125,12 @@ public abstract class AbstractArray implements TruffleObject {
         this(grCUDAExecutionContext, elementType, true);
     }
 
-    protected AbstractArray(AbstractGrCUDAExecutionContext grCUDAExecutionContext, Type elementType, boolean isLastComputationArrayAccess) {
+    protected AbstractArray(AbstractGrCUDAExecutionContext grCUDAExecutionContext, Type elementType, boolean isLastComputationCPUAccess) {
         this.grCUDAExecutionContext = grCUDAExecutionContext;
         this.elementType = elementType;
-        this.isLastComputationArrayAccess = isLastComputationArrayAccess;
+        this.isLastComputationCPUAccess = isLastComputationCPUAccess;
+        // Initialize the location of the array with a callback to the execution context, to avoid leaking access to the runtime here;
+        grCUDAExecutionContext.initializeArrayLocation(this);
     }
 
     /**
@@ -144,10 +157,29 @@ public abstract class AbstractArray implements TruffleObject {
         this.streamMapping = streamMapping;
     }
 
-    public boolean isLastComputationArrayAccess() { return isLastComputationArrayAccess; }
+    public boolean isLastComputationCPUAccess() { return isLastComputationCPUAccess; }
 
-    public synchronized void setLastComputationArrayAccess(boolean lastComputationArrayAccess) {
-        isLastComputationArrayAccess = lastComputationArrayAccess;
+    public void setLastComputationCPUAccess(boolean lastComputationCPUAccess) {
+        isLastComputationCPUAccess = lastComputationCPUAccess;
+    }
+
+    public Set<Integer> getArrayUpToDateLocations() {
+        return this.arrayUpToDateLocations;
+    }
+
+    /**
+     * Reset the list of devices where the array is currently up-to-date,
+     * and specify a new device where the array is up-to-date.
+     * Used when the array is modified by some device: there should never be a situation where
+     * the array is not up-to-date on at least one device;
+     */
+    public void resetArrayUpToDateLocations(int deviceId) {
+        this.arrayUpToDateLocations.clear();
+        this.arrayUpToDateLocations.add(deviceId);
+    }
+
+    public void addArrayUpToDateLocations(int deviceId) {
+        this.arrayUpToDateLocations.add(deviceId);
     }
 
     public abstract long getPointer();
@@ -256,7 +288,7 @@ public abstract class AbstractArray implements TruffleObject {
      * @return if this array can be accessed by the host without scheduling a computation
      */
     protected boolean canSkipScheduling() {
-        return this.isLastComputationArrayAccess() && !(this.streamMapping.isDefaultStream() && grCUDAExecutionContext.isAnyComputationActive());
+        return this.isLastComputationCPUAccess() && !(this.streamMapping.isDefaultStream() && grCUDAExecutionContext.isAnyComputationActive());
     }
 
     /**

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/DeviceArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/DeviceArray.java
@@ -177,7 +177,7 @@ public class DeviceArray extends AbstractArray implements TruffleObject {
             throw InvalidArrayIndexException.create(index);
         }
         try {
-            if (this.canSkipScheduling()) {
+            if (this.canSkipSchedulingRead()) {
                 // Fast path, skip the DAG scheduling;
                 return AbstractArray.readArrayElementNative(this.nativeView, index, this.elementType, elementTypeProfile);
             } else {
@@ -206,7 +206,7 @@ public class DeviceArray extends AbstractArray implements TruffleObject {
             CompilerDirectives.transferToInterpreter();
             throw InvalidArrayIndexException.create(index);
         }
-        if (this.canSkipScheduling()) {
+        if (this.canSkipSchedulingWrite()) {
             // Fast path, skip the DAG scheduling;
             AbstractArray.writeArrayElementNative(this.nativeView, index, value, elementType, valueLibrary, elementTypeProfile);
         } else {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/MultiDimDeviceArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/MultiDimDeviceArray.java
@@ -70,6 +70,14 @@ public class MultiDimDeviceArray extends AbstractArray implements TruffleObject 
     /** Mutable view onto the underlying memory buffer. */
     private final LittleEndianNativeArrayView nativeView;
 
+    /**
+     * If we modify the devices where this multi-dimensional array is updated, we also have to update its views.
+     * As this array does not track the views (but views track their parent), we do so lazily.
+     * When the location of this array is changed, we switch this flag. When we access the location of views, we update
+     * their location and reset this flag;
+     */
+    private boolean isViewLocationUpdated = true;
+
     public MultiDimDeviceArray(AbstractGrCUDAExecutionContext grCUDAExecutionContext, Type elementType, long[] dimensions,
                                boolean useColumnMajor) {
         super(grCUDAExecutionContext, elementType);
@@ -156,6 +164,36 @@ public class MultiDimDeviceArray extends AbstractArray implements TruffleObject 
     final boolean isIndexValidInDimension(long index, int dimension) {
         long numElementsInDim = getElementsInDimension(dimension);
         return (index > 0) && (index < numElementsInDim);
+    }
+
+    public boolean isViewLocationUpdated() {
+        return isViewLocationUpdated;
+    }
+
+    public void resetViewLocationUpdated() {
+        isViewLocationUpdated = true;
+    }
+
+    /**
+     * If we update the list of locations where this array is located,
+     * we flag this array so that its views will update their list of locations.
+     * The update is done lazily when we access (or update) the location list of a view;
+     */
+    @Override
+    public void resetArrayUpToDateLocations(int deviceId) {
+        super.resetArrayUpToDateLocations(deviceId);
+        this.isViewLocationUpdated = false;
+    }
+
+    /**
+     * If we update the list of locations where this array is located,
+     * we flag this array so that its views will update their list of locations.
+     * The update is done lazily when we access (or update) the location list of a view;
+     */
+    @Override
+    public void addArrayUpToDateLocations(int deviceId) {
+        super.addArrayUpToDateLocations(deviceId);
+        this.isViewLocationUpdated = false;
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/MultiDimDeviceArrayView.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/MultiDimDeviceArrayView.java
@@ -51,6 +51,8 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.profiles.ValueProfile;
 
+import java.util.Set;
+
 @ExportLibrary(InteropLibrary.class)
 public class MultiDimDeviceArrayView extends AbstractArray implements TruffleObject {
 
@@ -74,7 +76,8 @@ public class MultiDimDeviceArrayView extends AbstractArray implements TruffleObj
      * @param stride value used to jump to consecutive values in the array, and determined by the slice that has been extracted
      */
     public MultiDimDeviceArrayView(MultiDimDeviceArray mdDeviceArray, int dim, long offset, long stride) {
-        super(mdDeviceArray.grCUDAExecutionContext, mdDeviceArray.elementType, mdDeviceArray.isLastComputationCPUAccess());
+        // The up-to-date locations of the view are the same of the parent;
+        super(mdDeviceArray.grCUDAExecutionContext, mdDeviceArray.elementType, mdDeviceArray.arrayUpToDateLocations);
         this.mdDeviceArray = mdDeviceArray;
         this.thisDimension = dim;
         this.offset = offset; // Index at which this array view starts;
@@ -111,17 +114,57 @@ public class MultiDimDeviceArrayView extends AbstractArray implements TruffleObj
     }
 
     /**
-     * Propagate the flag to the parent array, so other temporary views are aware of this computation;
-     * @param lastComputationCPUAccess if the last computation on this array is a host read/write
+     * Propagate the array location to the parent array, so other temporary views are aware of this update;
+     * @param deviceId device with an updated view of this array;
      */
     @Override
-    public void setLastComputationCPUAccess(boolean lastComputationCPUAccess) {
-        super.setLastComputationCPUAccess(lastComputationCPUAccess);
-        this.mdDeviceArray.setLastComputationCPUAccess(lastComputationCPUAccess);
+    public void resetArrayUpToDateLocations(int deviceId) {
+        // No need to check the isViewLocationUpdated flag, we are clearing all the location lists;
+        this.arrayUpToDateLocations.clear();
+        this.arrayUpToDateLocations.add(deviceId);
+        this.mdDeviceArray.resetArrayUpToDateLocations(deviceId);
+    }
+
+    /**
+     * Propagate the array location to the parent array, so other temporary views are aware of this update;
+     * @param deviceId device with an updated view of this array;
+     */
+    @Override
+    public void addArrayUpToDateLocations(int deviceId) {
+        // Guarantee that the parent list of updated locations is the same as the view;
+        ensureUpdatedListConsistencyWithParent();
+        this.arrayUpToDateLocations.add(deviceId);
+        this.mdDeviceArray.addArrayUpToDateLocations(deviceId);
     }
 
     @Override
-    public boolean isLastComputationCPUAccess() { return this.mdDeviceArray.isLastComputationCPUAccess(); }
+    public boolean isArrayUpdatedInLocation(int deviceId) {
+        // Guarantee that the parent list of updated locations is the same as the view;
+        ensureUpdatedListConsistencyWithParent();
+        return super.isArrayUpdatedInLocation(deviceId);
+    }
+
+    @Override
+    public boolean isArrayUpdatedOnCPU() {
+        // Guarantee that the parent list of updated locations is the same as the view;
+        ensureUpdatedListConsistencyWithParent();
+        return super.isArrayUpdatedOnCPU();
+    }
+
+    @Override
+    public Set<Integer> getArrayUpToDateLocations() {
+        // Guarantee that the parent list of updated locations is the same as the view;
+        ensureUpdatedListConsistencyWithParent();
+        return super.getArrayUpToDateLocations();
+    }
+
+    private void ensureUpdatedListConsistencyWithParent() {
+        if (!this.mdDeviceArray.isViewLocationUpdated()) {
+            this.arrayUpToDateLocations.clear();
+            this.arrayUpToDateLocations.addAll(this.mdDeviceArray.getArrayUpToDateLocations());
+            this.mdDeviceArray.resetViewLocationUpdated();
+        }
+    }
 
     /**
      * Propagate the stream mapping to the parent array, so other temporary views are aware of this mapping;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/MultiDimDeviceArrayView.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/MultiDimDeviceArrayView.java
@@ -74,7 +74,7 @@ public class MultiDimDeviceArrayView extends AbstractArray implements TruffleObj
      * @param stride value used to jump to consecutive values in the array, and determined by the slice that has been extracted
      */
     public MultiDimDeviceArrayView(MultiDimDeviceArray mdDeviceArray, int dim, long offset, long stride) {
-        super(mdDeviceArray.grCUDAExecutionContext, mdDeviceArray.elementType, mdDeviceArray.isLastComputationArrayAccess());
+        super(mdDeviceArray.grCUDAExecutionContext, mdDeviceArray.elementType, mdDeviceArray.isLastComputationCPUAccess());
         this.mdDeviceArray = mdDeviceArray;
         this.thisDimension = dim;
         this.offset = offset; // Index at which this array view starts;
@@ -112,16 +112,16 @@ public class MultiDimDeviceArrayView extends AbstractArray implements TruffleObj
 
     /**
      * Propagate the flag to the parent array, so other temporary views are aware of this computation;
-     * @param lastComputationArrayAccess if the last computation on this array is a host read/write
+     * @param lastComputationCPUAccess if the last computation on this array is a host read/write
      */
     @Override
-    public void setLastComputationArrayAccess(boolean lastComputationArrayAccess) {
-        super.setLastComputationArrayAccess(lastComputationArrayAccess);
-        this.mdDeviceArray.setLastComputationArrayAccess(lastComputationArrayAccess);
+    public void setLastComputationCPUAccess(boolean lastComputationCPUAccess) {
+        super.setLastComputationCPUAccess(lastComputationCPUAccess);
+        this.mdDeviceArray.setLastComputationCPUAccess(lastComputationCPUAccess);
     }
 
     @Override
-    public boolean isLastComputationArrayAccess() { return this.mdDeviceArray.isLastComputationArrayAccess(); }
+    public boolean isLastComputationCPUAccess() { return this.mdDeviceArray.isLastComputationCPUAccess(); }
 
     /**
      * Propagate the stream mapping to the parent array, so other temporary views are aware of this mapping;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/MultiDimDeviceArrayView.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/array/MultiDimDeviceArrayView.java
@@ -76,8 +76,8 @@ public class MultiDimDeviceArrayView extends AbstractArray implements TruffleObj
      * @param stride value used to jump to consecutive values in the array, and determined by the slice that has been extracted
      */
     public MultiDimDeviceArrayView(MultiDimDeviceArray mdDeviceArray, int dim, long offset, long stride) {
-        // The up-to-date locations of the view are the same of the parent;
-        super(mdDeviceArray.grCUDAExecutionContext, mdDeviceArray.elementType, mdDeviceArray.arrayUpToDateLocations);
+        // The up-to-date locations of the view are the same of the parent, along with the context and type;
+        super(mdDeviceArray);
         this.mdDeviceArray = mdDeviceArray;
         this.thisDimension = dim;
         this.offset = offset; // Index at which this array view starts;
@@ -269,7 +269,7 @@ public class MultiDimDeviceArrayView extends AbstractArray implements TruffleObj
             throw InvalidArrayIndexException.create(index);
         }
         try {
-            if (this.canSkipScheduling()) {
+            if (this.canSkipSchedulingRead()) {
                 // Fast path, skip the DAG scheduling;
                 return readNativeView(index, elementTypeProfile);
             } else {
@@ -305,7 +305,7 @@ public class MultiDimDeviceArrayView extends AbstractArray implements TruffleObj
             CompilerDirectives.transferToInterpreter();
             throw InvalidArrayIndexException.create(index);
         }
-        if (this.canSkipScheduling()) {
+        if (this.canSkipSchedulingWrite()) {
             // Fast path, skip the DAG scheduling;
             writeNativeView(index, value, valueLibrary, elementTypeProfile);
         } else {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/GrCUDAComputationalElement.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/GrCUDAComputationalElement.java
@@ -60,7 +60,7 @@ public abstract class GrCUDAComputationalElement {
     /**
      * This list contains the original set of input arguments that are used to compute dependencies;
      */
-    protected final List<ComputationArgumentWithValue> argumentList;
+    protected final List<ComputationArgumentWithValue> argumentsThatCanCreateDependencies;
     /**
      * Reference to the execution context where this computation is executed;
      */
@@ -119,10 +119,10 @@ public abstract class GrCUDAComputationalElement {
      * @param initializer the initializer used to build the internal set of arguments considered in the dependency computation
      */
     public GrCUDAComputationalElement(AbstractGrCUDAExecutionContext grCUDAExecutionContext, InitializeDependencyList initializer) {
-        this.argumentList = initializer.initialize();
+        this.argumentsThatCanCreateDependencies = initializer.initialize();
         // Initialize by making a copy of the original set;
         this.grCUDAExecutionContext = grCUDAExecutionContext;
-        this.dependencyComputation = grCUDAExecutionContext.getDependencyBuilder().initialize(this.argumentList);
+        this.dependencyComputation = grCUDAExecutionContext.getDependencyBuilder().initialize(this.argumentsThatCanCreateDependencies);
     }
 
     /**
@@ -134,8 +134,8 @@ public abstract class GrCUDAComputationalElement {
         this(grCUDAExecutionContext, new DefaultExecutionInitializer(args));
     }
 
-    public List<ComputationArgumentWithValue> getArgumentList() {
-        return argumentList;
+    public List<ComputationArgumentWithValue> getArgumentsThatCanCreateDependencies() {
+        return argumentsThatCanCreateDependencies;
     }
 
     /**
@@ -291,7 +291,7 @@ public abstract class GrCUDAComputationalElement {
      * and there's no benefit in tracking their location;
      */
     public void updateLocationOfArrays() {
-        for (ComputationArgumentWithValue o : this.argumentList) {
+        for (ComputationArgumentWithValue o : this.argumentsThatCanCreateDependencies) {
             // Ignore non-array arguments. Also, don't update locations if the ComputationalElement does not use streams;
             if (o.getArgumentValue() instanceof AbstractArray && this.canUseStream()) {
                 AbstractArray a = (AbstractArray) o.getArgumentValue();

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/GrCUDAComputationalElement.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/GrCUDAComputationalElement.java
@@ -281,10 +281,12 @@ public abstract class GrCUDAComputationalElement {
     /**
      * Set for all the {@link com.nvidia.grcuda.runtime.array.AbstractArray} in the computation if this computation is an array access;
      */
-    public void updateIsComputationArrayAccess() {
+    public void updateIsComputationCPUAccess() {
         for (ComputationArgumentWithValue o : this.argumentList) {
             if (o.getArgumentValue() instanceof AbstractArray) {
-                ((AbstractArray) o.getArgumentValue()).setLastComputationCPUAccess(isComputationArrayAccess);
+                if (!(grCUDAExecutionContext.isConstAware() && o.isConst())) {
+                    ((AbstractArray) o.getArgumentValue()).setLastComputationCPUAccess(isComputationArrayAccess);
+                }
             }
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/GrCUDAComputationalElement.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/GrCUDAComputationalElement.java
@@ -284,7 +284,7 @@ public abstract class GrCUDAComputationalElement {
     public void updateIsComputationArrayAccess() {
         for (ComputationArgumentWithValue o : this.argumentList) {
             if (o.getArgumentValue() instanceof AbstractArray) {
-                ((AbstractArray) o.getArgumentValue()).setLastComputationArrayAccess(isComputationArrayAccess);
+                ((AbstractArray) o.getArgumentValue()).setLastComputationCPUAccess(isComputationArrayAccess);
             }
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/GrCUDAComputationalElement.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/GrCUDAComputationalElement.java
@@ -93,10 +93,11 @@ public abstract class GrCUDAComputationalElement {
      */
     private boolean computationStarted = false;
     /**
-     * Specify if this computational element represents an array access (read or write) on an {@link com.nvidia.grcuda.runtime.array.AbstractArray}
-     * performed synchronously by the CPU. By default it returns false;
+     * Specify if this computational element represents a computation executed on the CPU,
+     * such as an array access (read or write) on an {@link com.nvidia.grcuda.runtime.array.AbstractArray}.
+     * CPU computations are assumed synchronous. By default it returns false;
      */
-    protected boolean isComputationArrayAccess = false;
+    protected boolean isComputationDoneByCPU = false;
 
     private final DependencyComputation dependencyComputation;
 
@@ -183,7 +184,7 @@ public abstract class GrCUDAComputationalElement {
     public abstract Object execute() throws UnsupportedTypeException;
 
     public CUDAStream getStream() {
-        return stream;
+        return this.stream;
     }
 
     public void setStream(CUDAStream stream) {
@@ -235,7 +236,9 @@ public abstract class GrCUDAComputationalElement {
      * If not, the stream will be provided internally using the specified execution policy. By default, return false;
      * @return if the computation is done on a custom CUDA stream;
      */
-    public boolean useManuallySpecifiedStream() { return false; }
+    public boolean useManuallySpecifiedStream() {
+        return false;
+    }
 
     /**
      * Some computational elements, like kernels, can be executed on different {@link CUDAStream} to provide
@@ -243,7 +246,9 @@ public abstract class GrCUDAComputationalElement {
      * executed on streams different from the {@link DefaultStream};
      * @return if this computation can be executed on a customized stream
      */
-    public boolean canUseStream() { return false; }
+    public boolean canUseStream() {
+        return false;
+    }
 
     // TODO: currently not supported. It is not clear what the synchronization semantic for the default stream is.
     //  It is better to just always execute computations on the default stream synchronously.
@@ -279,13 +284,23 @@ public abstract class GrCUDAComputationalElement {
     public DependencyComputation getDependencyComputation() { return dependencyComputation; }
 
     /**
-     * Set for all the {@link com.nvidia.grcuda.runtime.array.AbstractArray} in the computation if this computation is an array access;
+     * Set for all the {@link com.nvidia.grcuda.runtime.array.AbstractArray} in the computation if this computation is an array access.
+     * This implementation is meant for GPU computations that use streams, e.g. kernels and GPU libraries.
+     * CPU computations (e.g. array accesses) should re-implement this function to track the CPU.
+     * GPU computations don't use custom streams only if the are synchronized (e.g. when using the sync scheduler),
+     * and there's no benefit in tracking their location;
      */
-    public void updateIsComputationCPUAccess() {
+    public void updateLocationOfArrays() {
         for (ComputationArgumentWithValue o : this.argumentList) {
-            if (o.getArgumentValue() instanceof AbstractArray) {
-                if (!(grCUDAExecutionContext.isConstAware() && o.isConst())) {
-                    ((AbstractArray) o.getArgumentValue()).setLastComputationCPUAccess(isComputationArrayAccess);
+            // Ignore non-array arguments. Also, don't update locations if the ComputationalElement does not use streams;
+            if (o.getArgumentValue() instanceof AbstractArray && this.canUseStream()) {
+                AbstractArray a = (AbstractArray) o.getArgumentValue();
+                // If the argument is read-only, add the location of this ComputationalElement to the array;
+                if (grCUDAExecutionContext.isConstAware() && o.isConst()) {
+                    a.addArrayUpToDateLocations(this.stream.getStreamDeviceId());
+                } else {
+                    // Clear the list of up-to-date locations: only the current device has the updated array;
+                    a.resetArrayUpToDateLocations(this.stream.getStreamDeviceId());
                 }
             }
         }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayAccessExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayAccessExecution.java
@@ -43,7 +43,10 @@ import java.util.Optional;
  */
 public abstract class ArrayAccessExecution<T extends AbstractArray> extends GrCUDAComputationalElement {
 
-    protected boolean isComputationArrayAccess = true;
+    public static final boolean COMPUTATION_IS_ARRAY_ACCESS = true;
+
+    protected boolean isComputationArrayAccess = COMPUTATION_IS_ARRAY_ACCESS;
+
     protected T array;
 
     public ArrayAccessExecution(AbstractGrCUDAExecutionContext grCUDAExecutionContext, InitializeDependencyList initializer, T array) {
@@ -53,7 +56,7 @@ public abstract class ArrayAccessExecution<T extends AbstractArray> extends GrCU
 
     @Override
     public void updateIsComputationArrayAccess() {
-        this.array.setLastComputationArrayAccess(isComputationArrayAccess);
+        this.array.setLastComputationCPUAccess(COMPUTATION_IS_ARRAY_ACCESS);
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayAccessExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayAccessExecution.java
@@ -55,7 +55,7 @@ public abstract class ArrayAccessExecution<T extends AbstractArray> extends GrCU
     }
 
     @Override
-    public void updateIsComputationArrayAccess() {
+    public void updateIsComputationCPUAccess() {
         this.array.setLastComputationCPUAccess(COMPUTATION_IS_ARRAY_ACCESS);
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayAccessExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayAccessExecution.java
@@ -44,10 +44,12 @@ import java.util.Optional;
 public abstract class ArrayAccessExecution<T extends AbstractArray> extends GrCUDAComputationalElement {
 
     protected T array;
+    public static final boolean COMPUTATION_IS_DONE_BY_CPU = true;
 
     public ArrayAccessExecution(AbstractGrCUDAExecutionContext grCUDAExecutionContext, InitializeDependencyList initializer, T array) {
         super(grCUDAExecutionContext, initializer);
         this.array = array;
+        this.isComputationDoneByCPU = COMPUTATION_IS_DONE_BY_CPU;
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecution.java
@@ -57,9 +57,9 @@ public abstract class ArrayCopyFunctionExecution extends GrCUDAComputationalElem
      */
     protected final long numElements;
 
-    protected boolean isComputationArrayAccess = true;
+    public static final boolean COMPUTATION_IS_ARRAY_ACCESS = true;
 
-    //FIXME: create constructor with executioninitiaizer as argument, then in the function that craete this class, use the constructor with iitializer if we have a second device array, else use default initializer
+    protected boolean isComputationArrayAccess = COMPUTATION_IS_ARRAY_ACCESS;
 
     public ArrayCopyFunctionExecution(AbstractArray array, DeviceArrayCopyFunction.CopyDirection direction, long numElements, ArrayCopyFunctionExecutionInitializer dependencyInitializer) {
         super(array.getGrCUDAExecutionContext(), dependencyInitializer);
@@ -86,7 +86,7 @@ public abstract class ArrayCopyFunctionExecution extends GrCUDAComputationalElem
 
     @Override
     public void updateIsComputationArrayAccess() {
-        this.array.setLastComputationArrayAccess(isComputationArrayAccess);
+        this.array.setLastComputationCPUAccess(COMPUTATION_IS_ARRAY_ACCESS);
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecution.java
@@ -85,7 +85,7 @@ public abstract class ArrayCopyFunctionExecution extends GrCUDAComputationalElem
     abstract void executeInner();
 
     @Override
-    public void updateIsComputationArrayAccess() {
+    public void updateIsComputationCPUAccess() {
         this.array.setLastComputationCPUAccess(COMPUTATION_IS_ARRAY_ACCESS);
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecution.java
@@ -58,14 +58,14 @@ public abstract class ArrayCopyFunctionExecution extends GrCUDAComputationalElem
      */
     protected final long numElements;
 
-    public static final boolean COMPUTATION_IS_ARRAY_ACCESS = true;
+    public static final boolean COMPUTATION_IS_DONE_BY_CPU = true;
 
     public ArrayCopyFunctionExecution(AbstractArray array, DeviceArrayCopyFunction.CopyDirection direction, long numElements, ArrayCopyFunctionExecutionInitializer dependencyInitializer) {
         super(array.getGrCUDAExecutionContext(), dependencyInitializer);
         this.array = array;
         this.direction = direction;
         this.numElements = numElements;
-        this.isComputationDoneByCPU = COMPUTATION_IS_ARRAY_ACCESS;
+        this.isComputationDoneByCPU = COMPUTATION_IS_DONE_BY_CPU;
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecutionDefault.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecutionDefault.java
@@ -30,6 +30,7 @@
  */
 package com.nvidia.grcuda.runtime.computation.arraycomputation;
 
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.AbstractArray;
 import com.nvidia.grcuda.functions.DeviceArrayCopyFunction;
 import com.oracle.truffle.api.CompilerDirectives;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecutionMemcpy.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/ArrayCopyFunctionExecutionMemcpy.java
@@ -30,6 +30,7 @@
  */
 package com.nvidia.grcuda.runtime.computation.arraycomputation;
 
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.AbstractArray;
 import com.nvidia.grcuda.functions.DeviceArrayCopyFunction;
 import com.oracle.truffle.api.CompilerDirectives;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/DeviceArrayReadExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/DeviceArrayReadExecution.java
@@ -30,6 +30,7 @@
  */
 package com.nvidia.grcuda.runtime.computation.arraycomputation;
 
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.DeviceArray;
 import com.oracle.truffle.api.profiles.ValueProfile;
 
@@ -39,11 +40,21 @@ public class DeviceArrayReadExecution extends ArrayAccessExecution<DeviceArray> 
     private final ValueProfile elementTypeProfile;
 
     public DeviceArrayReadExecution(DeviceArray array,
-                                     long index,
-                                     ValueProfile elementTypeProfile) {
+                                    long index,
+                                    ValueProfile elementTypeProfile) {
         super(array.getGrCUDAExecutionContext(), new ArrayAccessExecutionInitializer<>(array, true), array);
         this.index = index;
         this.elementTypeProfile = elementTypeProfile;
+    }
+
+    @Override
+    public void updateLocationOfArrays() {
+        if (array.getGrCUDAExecutionContext().isConstAware()) {
+            array.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        } else {
+            // Clear the list of up-to-date locations: only the CPU has the updated array;
+            array.resetArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        }
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/DeviceArrayWriteExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/DeviceArrayWriteExecution.java
@@ -31,6 +31,7 @@
 package com.nvidia.grcuda.runtime.computation.arraycomputation;
 
 import com.nvidia.grcuda.NoneValue;
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.DeviceArray;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
@@ -53,6 +54,12 @@ public class DeviceArrayWriteExecution extends ArrayAccessExecution<DeviceArray>
         this.value = value;
         this.valueLibrary = valueLibrary;
         this.elementTypeProfile = elementTypeProfile;
+    }
+
+    @Override
+    public void updateLocationOfArrays() {
+        // Clear the list of up-to-date locations: only the CPU has the updated array;
+        array.resetArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/MultiDimDeviceArrayViewReadExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/MultiDimDeviceArrayViewReadExecution.java
@@ -30,6 +30,7 @@
  */
 package com.nvidia.grcuda.runtime.computation.arraycomputation;
 
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.MultiDimDeviceArrayView;
 import com.oracle.truffle.api.profiles.ValueProfile;
 
@@ -44,6 +45,16 @@ public class MultiDimDeviceArrayViewReadExecution extends ArrayAccessExecution<M
         super(array.getGrCUDAExecutionContext(), new ArrayAccessExecutionInitializer<>(array.getMdDeviceArray(), true), array);
         this.index = index;
         this.elementTypeProfile = elementTypeProfile;
+    }
+
+    @Override
+    public void updateLocationOfArrays() {
+        if (array.getGrCUDAExecutionContext().isConstAware()) {
+            array.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        } else {
+            // Clear the list of up-to-date locations: only the CPU has the updated array;
+            array.resetArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        }
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/MultiDimDeviceArrayViewWriteExecution.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/arraycomputation/MultiDimDeviceArrayViewWriteExecution.java
@@ -31,6 +31,7 @@
 package com.nvidia.grcuda.runtime.computation.arraycomputation;
 
 import com.nvidia.grcuda.NoneValue;
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.MultiDimDeviceArrayView;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
@@ -53,6 +54,16 @@ public class MultiDimDeviceArrayViewWriteExecution extends ArrayAccessExecution<
         this.value = value;
         this.valueLibrary = valueLibrary;
         this.elementTypeProfile = elementTypeProfile;
+    }
+
+    @Override
+    public void updateLocationOfArrays() {
+        if (array.getGrCUDAExecutionContext().isConstAware()) {
+            array.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        } else {
+            // Clear the list of up-to-date locations: only the CPU has the updated array;
+            array.resetArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        }
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/AsyncArrayPrefetcher.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/AsyncArrayPrefetcher.java
@@ -52,7 +52,7 @@ public class AsyncArrayPrefetcher extends AbstractArrayPrefetcher {
      */
     @Override
     public void prefetchToGpu(GrCUDAComputationalElement computation) {
-        for (ComputationArgumentWithValue a : computation.getArgumentList()) {
+        for (ComputationArgumentWithValue a : computation.getArgumentsThatCanCreateDependencies()) {
             if (a.getArgumentValue() instanceof AbstractArray) {
                 AbstractArray array = (AbstractArray) a.getArgumentValue();
                 // The array has been used by the CPU, so we should prefetch it;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/AsyncArrayPrefetcher.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/AsyncArrayPrefetcher.java
@@ -56,7 +56,7 @@ public class AsyncArrayPrefetcher extends AbstractArrayPrefetcher {
             if (a.getArgumentValue() instanceof AbstractArray) {
                 AbstractArray array = (AbstractArray) a.getArgumentValue();
                 // The array has been used by the CPU, so we should prefetch it;
-                if (array.isLastComputationArrayAccess()) {
+                if (array.isLastComputationCPUAccess()) {
                     CUDAStream streamToPrefetch = computation.getStream();
                     runtime.cudaMemPrefetchAsync(array, streamToPrefetch);
                 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/AsyncArrayPrefetcher.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/AsyncArrayPrefetcher.java
@@ -56,7 +56,7 @@ public class AsyncArrayPrefetcher extends AbstractArrayPrefetcher {
             if (a.getArgumentValue() instanceof AbstractArray) {
                 AbstractArray array = (AbstractArray) a.getArgumentValue();
                 // The array has been used by the CPU, so we should prefetch it;
-                if (array.isLastComputationCPUAccess()) {
+                if (array.isArrayUpdatedOnCPU()) {
                     CUDAStream streamToPrefetch = computation.getStream();
                     runtime.cudaMemPrefetchAsync(array, streamToPrefetch);
                 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/SyncArrayPrefetcher.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/SyncArrayPrefetcher.java
@@ -52,7 +52,7 @@ public class SyncArrayPrefetcher extends AbstractArrayPrefetcher {
      */
     @Override
     public void prefetchToGpu(GrCUDAComputationalElement computation) {
-        for (ComputationArgumentWithValue a : computation.getArgumentList()) {
+        for (ComputationArgumentWithValue a : computation.getArgumentsThatCanCreateDependencies()) {
             if (a.getArgumentValue() instanceof AbstractArray) {
                 AbstractArray array = (AbstractArray) a.getArgumentValue();
                 // The array has been used by the CPU, so we should prefetch it;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/SyncArrayPrefetcher.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/SyncArrayPrefetcher.java
@@ -56,7 +56,7 @@ public class SyncArrayPrefetcher extends AbstractArrayPrefetcher {
             if (a.getArgumentValue() instanceof AbstractArray) {
                 AbstractArray array = (AbstractArray) a.getArgumentValue();
                 // The array has been used by the CPU, so we should prefetch it;
-                if (array.isLastComputationCPUAccess()) {
+                if (array.isArrayUpdatedOnCPU()) {
                     CUDAStream streamToPrefetch = computation.getStream();
                     runtime.cudaMemPrefetchAsync(array, streamToPrefetch);
                     runtime.cudaStreamSynchronize(streamToPrefetch);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/SyncArrayPrefetcher.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/prefetch/SyncArrayPrefetcher.java
@@ -56,7 +56,7 @@ public class SyncArrayPrefetcher extends AbstractArrayPrefetcher {
             if (a.getArgumentValue() instanceof AbstractArray) {
                 AbstractArray array = (AbstractArray) a.getArgumentValue();
                 // The array has been used by the CPU, so we should prefetch it;
-                if (array.isLastComputationArrayAccess()) {
+                if (array.isLastComputationCPUAccess()) {
                     CUDAStream streamToPrefetch = computation.getStream();
                     runtime.cudaMemPrefetchAsync(array, streamToPrefetch);
                     runtime.cudaStreamSynchronize(streamToPrefetch);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/AbstractGrCUDAExecutionContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/AbstractGrCUDAExecutionContext.java
@@ -34,6 +34,7 @@ import com.nvidia.grcuda.Binding;
 import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.GrCUDALogger;
 import com.nvidia.grcuda.GrCUDAOptionMap;
+import com.nvidia.grcuda.runtime.CPUDevice;
 import com.nvidia.grcuda.runtime.array.AbstractArray;
 import com.nvidia.grcuda.runtime.CUDARuntime;
 import com.nvidia.grcuda.runtime.Kernel;
@@ -161,4 +162,17 @@ public abstract class AbstractGrCUDAExecutionContext {
      * Delete internal structures that require manual cleanup operations;
      */
     public void cleanup() { }
+
+    /**
+     * Initialize the location of an abstract array.
+     * On pre-Pascal devices, the default location is the current GPU. Since Pascal, it is the CPU;
+     * @param array the array for which we initialize the location;
+     */
+    public void initializeArrayLocation(AbstractArray array) {
+        if (cudaRuntime.isArchitectureIsPascalOrNewer()) {
+            array.addArrayUpToDateLocations(CPUDevice.CPU_DEVICE_ID);
+        } else {
+            array.addArrayUpToDateLocations(cudaRuntime.getCurrentGPU());
+        }
+    }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/AsyncGrCUDAExecutionContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/AsyncGrCUDAExecutionContext.java
@@ -119,6 +119,8 @@ public class AsyncGrCUDAExecutionContext extends AbstractGrCUDAExecutionContext 
 
         // Perform the computation;
         vertex.getComputation().setComputationStarted();
+
+        // For all input arrays, update whether this computation is an array access done by the CPU;
         vertex.getComputation().updateIsComputationArrayAccess();
 
         // Associate a CUDA event to the starting phase of the computation in order to get the Elapsed time from start to the end

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/AsyncGrCUDAExecutionContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/AsyncGrCUDAExecutionContext.java
@@ -121,7 +121,7 @@ public class AsyncGrCUDAExecutionContext extends AbstractGrCUDAExecutionContext 
         vertex.getComputation().setComputationStarted();
 
         // For all input arrays, update whether this computation is an array access done by the CPU;
-        vertex.getComputation().updateIsComputationArrayAccess();
+        vertex.getComputation().updateIsComputationCPUAccess();
 
         // Associate a CUDA event to the starting phase of the computation in order to get the Elapsed time from start to the end
         streamManager.assignEventStart(vertex);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/AsyncGrCUDAExecutionContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/AsyncGrCUDAExecutionContext.java
@@ -121,7 +121,7 @@ public class AsyncGrCUDAExecutionContext extends AbstractGrCUDAExecutionContext 
         vertex.getComputation().setComputationStarted();
 
         // For all input arrays, update whether this computation is an array access done by the CPU;
-        vertex.getComputation().updateIsComputationCPUAccess();
+        vertex.getComputation().updateLocationOfArrays();
 
         // Associate a CUDA event to the starting phase of the computation in order to get the Elapsed time from start to the end
         streamManager.assignEventStart(vertex);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/SyncGrCUDAExecutionContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/SyncGrCUDAExecutionContext.java
@@ -70,7 +70,7 @@ public class SyncGrCUDAExecutionContext extends AbstractGrCUDAExecutionContext {
         computation.setComputationStarted();
 
         // For all input arrays, update whether this computation is an array access done by the CPU;
-        computation.updateIsComputationArrayAccess();
+        computation.updateIsComputationCPUAccess();
 
         // Start the computation immediately;
         Object result = computation.execute();

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/SyncGrCUDAExecutionContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/SyncGrCUDAExecutionContext.java
@@ -70,7 +70,7 @@ public class SyncGrCUDAExecutionContext extends AbstractGrCUDAExecutionContext {
         computation.setComputationStarted();
 
         // For all input arrays, update whether this computation is an array access done by the CPU;
-        computation.updateIsComputationCPUAccess();
+        computation.updateLocationOfArrays();
 
         // Start the computation immediately;
         Object result = computation.execute();

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/SyncGrCUDAExecutionContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/SyncGrCUDAExecutionContext.java
@@ -68,6 +68,8 @@ public class SyncGrCUDAExecutionContext extends AbstractGrCUDAExecutionContext {
 
         // Book-keeping;
         computation.setComputationStarted();
+
+        // For all input arrays, update whether this computation is an array access done by the CPU;
         computation.updateIsComputationArrayAccess();
 
         // Start the computation immediately;


### PR DESCRIPTION
* Replaced old `isLastComputationArrayAccess"` with new device tracking API
* The old `isLastComputationArrayAccess` was a performance optimization used to track if the last computation on an array was an access done by the CPU (the only existing CPU computations), to skip scheduling of further array accesses done by the CPU 
* Implicitly, the API tracked if a certain array was up-to-date on the CPU or on the GPU (for a 1 GPU system).
* The new API that tracks locations of arrays completely covers the old API, making it redundant. If an array is up-to-date on the CPU, we can perform read/write without any ComputationalElement scheduling.
* Checking if an array is up-to-date on the CPU requires a hashset lookup. It might be optimized if necessary, using a tracking flag.

**Possible error: Array A is up-to-date on CPU and GPU0. There's an ongoing kernel on GPU0 that uses A read-only. If we write A on the CPU, is the scheduling skipped? That's an error** <- A fix to this has been added to GRCUDA-96-6

**PR stacked on GRCUDA-96-4, to be merged on master after GRCUDA-96-4**